### PR TITLE
Implementation of Intermediate Process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-unit: .coverage
 	$(GO) test ./... -covermode=atomic -coverprofile=.coverage/coverage_unit.txt
 
 test-integration: .coverage
-	$(GO) test ./pkg/test/... -tags=integration -covermode=atomic -coverprofile=.coverage/coverage_integration.txt -coverpkg github.com/vmware/go-ipfix/pkg/collector,github.com/vmware/go-ipfix/pkg/exporter
+	$(GO) test ./pkg/test/... -tags=integration -covermode=atomic -coverprofile=coverage_integration.txt -coverpkg github.com/vmware/go-ipfix/pkg/collector,github.com/vmware/go-ipfix/pkg/exporter,github.com/vmware/go-ipfix/pkg/intermediate
 
 golangci:
 	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.21.0

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-unit: .coverage
 	$(GO) test ./... -covermode=atomic -coverprofile=.coverage/coverage_unit.txt
 
 test-integration: .coverage
-	$(GO) test ./pkg/test/... -tags=integration -covermode=atomic -coverprofile=coverage_integration.txt -coverpkg github.com/vmware/go-ipfix/pkg/collector,github.com/vmware/go-ipfix/pkg/exporter,github.com/vmware/go-ipfix/pkg/intermediate
+	$(GO) test ./pkg/test/... -tags=integration -covermode=atomic -coverprofile=.coverage/coverage_integration.txt -coverpkg github.com/vmware/go-ipfix/pkg/collector,github.com/vmware/go-ipfix/pkg/exporter,github.com/vmware/go-ipfix/pkg/intermediate
 
 golangci:
 	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.21.0

--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -77,7 +77,7 @@ func printIPFIXMessage(msg *entities.Message) {
 		fmt.Fprint(&buf, "TEMPLATE SET:\n")
 		for i, record := range msg.Set.GetRecords() {
 			fmt.Fprintf(&buf, "  TEMPLATE RECORD-%d:\n", i)
-			for _, ie := range record.GetInfoElements() {
+			for _, ie := range record.GetOrderedElementList() {
 				fmt.Fprintf(&buf, "    %s: len=%d (enterprise ID = %d) \n", ie.Element.Name, ie.Element.Len, ie.Element.EnterpriseId)
 			}
 		}
@@ -85,7 +85,7 @@ func printIPFIXMessage(msg *entities.Message) {
 		fmt.Fprint(&buf, "DATA SET:\n")
 		for i, record := range msg.Set.GetRecords() {
 			fmt.Fprintf(&buf, "  DATA RECORD-%d:\n", i)
-			for _, ie := range record.GetInfoElements() {
+			for _, ie := range record.GetOrderedElementList() {
 				fmt.Fprintf(&buf, "    %s: %v \n", ie.Element.Name, ie.Value)
 			}
 		}
@@ -130,7 +130,7 @@ func run() error {
 		return fmt.Errorf("input given ipfix.transport flag is not supported or valid")
 	}
 	// Initialize collecting process
-	cp, err := collector.InitCollectingProcess(netAddr, 65535, 0, false)
+	cp, err := collector.InitCollectingProcess(netAddr, 65535, 0)
 	if err != nil {
 		return err
 	}

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,7 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4 h1:Toz2IK7k8rbltAXwNAxKcn9OzqyNfMUhUNjz3sL0NMk=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -47,8 +47,6 @@ type collectingProcess struct {
 	useMsgChan bool
 	// messageChan is the channel to output message
 	messageChan chan *entities.Message
-	// messageList is the list to store all messages
-	messageList []*entities.Message
 	// maps each client to its client handler (required channels)
 	clients map[string]*clientHandler
 	// clientsLock allows multiple readers or one writer to access clients map at the same time
@@ -70,7 +68,6 @@ func InitCollectingProcess(address net.Addr, maxBufferSize uint16, templateTTL u
 		stopChan:      make(chan bool),
 		useMsgChan:    useMsgChan,
 		messageChan:   make(chan *entities.Message),
-		messageList:   make([]*entities.Message, 0),
 		clients:       make(map[string]*clientHandler),
 	}
 	return collectProc, nil
@@ -96,13 +93,6 @@ func (cp *collectingProcess) GetMsgChan() chan *entities.Message {
 		return nil
 	}
 	return cp.messageChan
-}
-
-func (cp *collectingProcess) GetMsgList() []*entities.Message {
-	if cp.useMsgChan {
-		return nil
-	}
-	return cp.messageList
 }
 
 func (cp *collectingProcess) createClient() *clientHandler {
@@ -158,8 +148,6 @@ func (cp *collectingProcess) decodePacket(packetBuffer *bytes.Buffer, exportAddr
 	if cp.useMsgChan {
 		// the thread(s)/client(s) executing the code will get blocked until the message is consumed/read in other goroutines.
 		cp.messageChan <- &message
-	} else {
-		cp.messageList = append(cp.messageList, &message)
 	}
 	return &message, nil
 }

--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -47,6 +47,8 @@ type collectingProcess struct {
 	useMsgChan bool
 	// messageChan is the channel to output message
 	messageChan chan *entities.Message
+	// messageList is the list to store all messages
+	messageList []*entities.Message
 	// maps each client to its client handler (required channels)
 	clients map[string]*clientHandler
 	// clientsLock allows multiple readers or one writer to access clients map at the same time
@@ -68,6 +70,7 @@ func InitCollectingProcess(address net.Addr, maxBufferSize uint16, templateTTL u
 		stopChan:      make(chan bool),
 		useMsgChan:    useMsgChan,
 		messageChan:   make(chan *entities.Message),
+		messageList:   make([]*entities.Message, 0),
 		clients:       make(map[string]*clientHandler),
 	}
 	return collectProc, nil
@@ -93,6 +96,13 @@ func (cp *collectingProcess) GetMsgChan() chan *entities.Message {
 		return nil
 	}
 	return cp.messageChan
+}
+
+func (cp *collectingProcess) GetMsgList() []*entities.Message {
+	if cp.useMsgChan {
+		return nil
+	}
+	return cp.messageList
 }
 
 func (cp *collectingProcess) createClient() *clientHandler {
@@ -148,6 +158,8 @@ func (cp *collectingProcess) decodePacket(packetBuffer *bytes.Buffer, exportAddr
 	if cp.useMsgChan {
 		// the thread(s)/client(s) executing the code will get blocked until the message is consumed/read in other goroutines.
 		cp.messageChan <- &message
+	} else {
+		cp.messageList = append(cp.messageList, &message)
 	}
 	return &message, nil
 }

--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -44,7 +44,7 @@ func TestTCPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, err := InitCollectingProcess(address, 1024, 0)
+	cp, err := InitCollectingProcess(address, 1024, 0, nil)
 	if err != nil {
 		t.Fatalf("TCP Collecting Process does not start correctly: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, err := InitCollectingProcess(address, 1024, 0)
+	cp, err := InitCollectingProcess(address, 1024, 0, nil)
 	if err != nil {
 		t.Fatalf("UDP Collecting Process does not start correctly: %v", err)
 	}
@@ -100,7 +100,9 @@ func TestTCPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, err := InitCollectingProcess(address, 1024, 0)
+	messageChan := make(chan *entities.Message)
+	messageCount := 0
+	cp, err := InitCollectingProcess(address, 1024, 0, messageChan)
 	// Add the templates before sending data record
 	cp.addTemplate(uint32(1), uint16(256), elementsWithValue)
 	if err != nil {
@@ -114,13 +116,16 @@ func TestTCPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 		}
 		defer conn.Close()
 		conn.Write(validDataPacket)
+		for range messageChan {
+			messageCount++
+		}
 	}()
 	go func() {
 		time.Sleep(4 * time.Second)
 		cp.Stop()
 	}()
 	cp.Start()
-	assert.Equal(t, 1, len(cp.messages), "TCP Collecting Process should receive and store the received data record.")
+	assert.Equal(t, 1, messageCount, "TCP Collecting Process should receive and store the received data record.")
 }
 
 func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
@@ -128,7 +133,9 @@ func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, err := InitCollectingProcess(address, 1024, 0)
+	messageChan := make(chan *entities.Message)
+	messageCount := 0
+	cp, err := InitCollectingProcess(address, 1024, 0, messageChan)
 	// Add the templates before sending data record
 	cp.addTemplate(uint32(1), uint16(256), elementsWithValue)
 	if err != nil {
@@ -146,13 +153,16 @@ func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 		}
 		defer conn.Close()
 		conn.Write(validDataPacket)
+		for range messageChan {
+			messageCount++
+		}
 	}()
 	go func() {
 		time.Sleep(5 * time.Second)
 		cp.Stop()
 	}()
 	cp.Start()
-	assert.Equal(t, 1, len(cp.messages), "UDP Collecting Process should receive and store the received data record.")
+	assert.Equal(t, 1, messageCount, "UDP Collecting Process should receive and store the received data record.")
 }
 
 func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
@@ -160,7 +170,7 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, _ := InitCollectingProcess(address, 1024, 0)
+	cp, _ := InitCollectingProcess(address, 1024, 0, nil)
 	go func() {
 		time.Sleep(time.Second)
 		_, err := net.Dial(address.Network(), address.String())
@@ -186,7 +196,7 @@ func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, _ := InitCollectingProcess(address, 1024, 0)
+	cp, _ := InitCollectingProcess(address, 1024, 0, nil)
 	go func() {
 		time.Sleep(time.Second)
 		resolveAddr, err := net.ResolveUDPAddr(address.Network(), address.String())
@@ -231,7 +241,7 @@ func TestCollectingProcess_DecodeTemplateRecord(t *testing.T) {
 		t.Error(err)
 	}
 	cp.address = address
-	message, err := cp.decodePacket(bytes.NewBuffer(validTemplatePacket))
+	message, err := cp.decodePacket(bytes.NewBuffer(validTemplatePacket), address.String())
 	if err != nil {
 		t.Fatalf("Got error in decoding template record: %v", err)
 	}
@@ -247,12 +257,12 @@ func TestCollectingProcess_DecodeTemplateRecord(t *testing.T) {
 	assert.Equal(t, uint32(0), elements[0].Element.EnterpriseId, "Template record is not stored correctly.")
 	// Invalid version
 	templateRecord := []byte{0, 9, 0, 40, 95, 40, 211, 236, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 24, 1, 0, 0, 3, 0, 8, 0, 4, 0, 12, 0, 4, 128, 105, 255, 255, 0, 0, 218, 21}
-	_, err = cp.decodePacket(bytes.NewBuffer(templateRecord))
+	_, err = cp.decodePacket(bytes.NewBuffer(templateRecord), address.String())
 	assert.NotNil(t, err, "Error should be logged for invalid version")
 	// Malformed record
 	templateRecord = []byte{0, 10, 0, 40, 95, 40, 211, 236, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 24, 1, 0, 0, 3, 0, 8, 0, 4, 0, 12, 0, 4, 128, 105, 255, 255, 0, 0}
 	cp.templatesMap = make(map[uint32]map[uint16][]*entities.InfoElement)
-	_, err = cp.decodePacket(bytes.NewBuffer(templateRecord))
+	_, err = cp.decodePacket(bytes.NewBuffer(templateRecord), address.String())
 	assert.NotNil(t, err, "Error should be logged for malformed template record")
 	if _, exist := cp.templatesMap[uint32(1)]; exist {
 		t.Fatal("Template should not be stored for malformed template record")
@@ -269,11 +279,11 @@ func TestCollectingProcess_DecodeDataRecord(t *testing.T) {
 	}
 	cp.address = address
 	// Decode without template
-	_, err = cp.decodePacket(bytes.NewBuffer(validDataPacket))
+	_, err = cp.decodePacket(bytes.NewBuffer(validDataPacket), address.String())
 	assert.NotNil(t, err, "Error should be logged if corresponding template does not exist.")
 	// Decode with template
 	cp.addTemplate(uint32(1), uint16(256), elementsWithValue)
-	message, err := cp.decodePacket(bytes.NewBuffer(validDataPacket))
+	message, err := cp.decodePacket(bytes.NewBuffer(validDataPacket), address.String())
 	assert.Nil(t, err, "Error should not be logged if corresponding template exists.")
 	assert.Equal(t, uint16(10), message.Version, "Flow record version should be 10.")
 	assert.Equal(t, uint32(1), message.ObsDomainID, "Flow record obsDomainID should be 1.")
@@ -285,9 +295,11 @@ func TestCollectingProcess_DecodeDataRecord(t *testing.T) {
 	ipAddress := net.IP([]byte{1, 2, 3, 4})
 	elements := v.GetRecords()[0].GetInfoElements()
 	assert.Equal(t, ipAddress, elements[0].Value, "sourceIPv4Address should be decoded and stored correctly.")
+	assert.Equal(t, uint32(0), elements[3].Value, "originalExporterIPv4Address should be added to record correctly.")
+	assert.Equal(t, uint32(1), elements[4].Value, "originalObservationDomainId should be added to record correctly.")
 	// Malformed data record
 	dataRecord := []byte{0, 10, 0, 33, 95, 40, 212, 159, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0}
-	_, err = cp.decodePacket(bytes.NewBuffer(dataRecord))
+	_, err = cp.decodePacket(bytes.NewBuffer(dataRecord), address.String())
 	assert.NotNil(t, err, "Error should be logged for malformed data record")
 }
 
@@ -296,7 +308,7 @@ func TestUDPCollectingProcess_TemplateExpire(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, err := InitCollectingProcess(address, 1024, 5)
+	cp, err := InitCollectingProcess(address, 1024, 5, nil)
 	if err != nil {
 		t.Fatalf("UDP Collecting Process does not start correctly: %v", err)
 	}
@@ -324,4 +336,63 @@ func TestUDPCollectingProcess_TemplateExpire(t *testing.T) {
 	assert.NotNil(t, cp.templatesMap[1][256], "Template should be stored in the template map.")
 	time.Sleep(10 * time.Second)
 	assert.Nil(t, cp.templatesMap[1][256], "Template should be deleted after 5 seconds.")
+}
+
+func TestAddOriginalExporterInfo(t *testing.T) {
+	// Test message with template set
+	message := createMsgwithTemplateSet()
+	addOriginalExporterInfo(message)
+	record := message.Set.GetRecords()[0]
+	assert.Equal(t, "originalExporterIPv4Address", record.GetInfoElements()[5].Element.Name)
+	assert.Equal(t, "originalObservationDomainId", record.GetInfoElements()[6].Element.Name)
+	// Test message with data set
+	message = createMsgwithDataSet()
+	addOriginalExporterInfo(message)
+	record = message.Set.GetRecords()[0]
+	assert.Equal(t, "originalExporterIPv4Address", record.GetInfoElements()[5].Element.Name)
+	assert.Equal(t, uint32(2130706433), record.GetInfoElements()[5].Value)
+	assert.Equal(t, "originalObservationDomainId", record.GetInfoElements()[6].Element.Name)
+	assert.Equal(t, uint32(1234), record.GetInfoElements()[6].Value)
+}
+
+func createMsgwithTemplateSet() *entities.Message {
+	set := entities.NewSet(entities.Template, 256, false)
+	elements := make([]*entities.InfoElementWithValue, 0)
+	ie1 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+	ie2 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
+	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), nil)
+	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), nil)
+	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), nil)
+	elements = append(elements, ie1, ie2, ie3, ie4, ie5)
+	set.AddRecord(elements, 256)
+	return &entities.Message{
+		Version:       10,
+		BufferLength:  40,
+		SeqNumber:     1,
+		ObsDomainID:   5678,
+		ExportTime:    0,
+		ExportAddress: "127.0.0.1",
+		Set:           set,
+	}
+}
+
+func createMsgwithDataSet() *entities.Message {
+	set := entities.NewSet(entities.Data, 256, false)
+	elements := make([]*entities.InfoElementWithValue, 0)
+	ie1 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
+	ie2 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("10.0.0.2"))
+	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), uint16(1234))
+	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), uint16(5678))
+	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), uint8(6))
+	elements = append(elements, ie1, ie2, ie3, ie4, ie5)
+	set.AddRecord(elements, 256)
+	return &entities.Message{
+		Version:       10,
+		BufferLength:  32,
+		SeqNumber:     1,
+		ObsDomainID:   uint32(1234),
+		ExportTime:    0,
+		ExportAddress: "127.0.0.1",
+		Set:           set,
+	}
 }

--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -44,10 +44,11 @@ func TestTCPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, err := InitCollectingProcess(address, 1024, 0, false)
+	cp, err := InitCollectingProcess(address, 1024, 0, true)
 	if err != nil {
 		t.Fatalf("TCP Collecting Process does not start correctly: %v", err)
 	}
+	messageCount := 0
 	go func() {
 		time.Sleep(2 * time.Second)
 		conn, err := net.Dial(address.Network(), address.String())
@@ -56,6 +57,11 @@ func TestTCPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 		}
 		defer conn.Close()
 		conn.Write(validTemplatePacket)
+		time.Sleep(time.Second)
+		msgChan := cp.GetMsgChan()
+		for range msgChan {
+			messageCount++
+		}
 	}()
 	go func() {
 		time.Sleep(4 * time.Second)
@@ -63,8 +69,7 @@ func TestTCPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 	}()
 	cp.Start()
 	assert.NotNil(t, cp.templatesMap[1], "TCP Collecting Process should receive and store the received template.")
-	assert.Equal(t, 1, len(cp.GetMsgList()), "messageList should store the message when useMsgChan is set to false.")
-	assert.Nil(t, cp.GetMsgChan(), "messageChan should be nil when useMsgChan is set to false.")
+	assert.Equal(t, 1, messageCount, "Messages should be stored correctly.")
 }
 
 func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
@@ -72,10 +77,11 @@ func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp, err := InitCollectingProcess(address, 1024, 0, false)
+	cp, err := InitCollectingProcess(address, 1024, 0, true)
 	if err != nil {
 		t.Fatalf("UDP Collecting Process does not start correctly: %v", err)
 	}
+	messageCount := 0
 	go func() {
 		time.Sleep(2 * time.Second)
 		resolveAddr, err := net.ResolveUDPAddr(address.Network(), address.String())
@@ -88,6 +94,11 @@ func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 		}
 		defer conn.Close()
 		conn.Write(validTemplatePacket)
+		time.Sleep(time.Second)
+		msgChan := cp.GetMsgChan()
+		for range msgChan {
+			messageCount++
+		}
 	}()
 	go func() {
 		time.Sleep(4 * time.Second)
@@ -95,8 +106,7 @@ func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 	}()
 	cp.Start()
 	assert.NotNil(t, cp.templatesMap[1], "UDP Collecting Process should receive and store the received template.")
-	assert.Equal(t, 1, len(cp.GetMsgList()), "messageList should store the message when useMsgChan is set to false.")
-	assert.Nil(t, cp.GetMsgChan(), "messageChan should be nil when useMsgChan is set to false.")
+	assert.Equal(t, 1, messageCount, "Messages should be stored correctly.")
 }
 
 func TestTCPCollectingProcess_ReceiveDataRecord(t *testing.T) {
@@ -119,7 +129,9 @@ func TestTCPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 		}
 		defer conn.Close()
 		conn.Write(validDataPacket)
-		for range cp.GetMsgChan() {
+		time.Sleep(time.Second)
+		msgChan := cp.GetMsgChan()
+		for range msgChan {
 			messageCount++
 		}
 	}()

--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -255,8 +255,8 @@ func TestCollectingProcess_DecodeTemplateRecord(t *testing.T) {
 	if !ok {
 		t.Error("Template packet is not decoded correctly.")
 	}
-	assert.Equal(t, true, templateSet.GetRecords()[0].ContainsInfoElement("sourceIPv4Address"))
-	sourceIPv4Address := templateSet.GetRecords()[0].GetInfoElement("sourceIPv4Address")
+	sourceIPv4Address, exist := templateSet.GetRecords()[0].GetInfoElementMap()["sourceIPv4Address"]
+	assert.Equal(t, true, exist)
 	assert.Equal(t, uint32(0), sourceIPv4Address.Element.EnterpriseId, "Template record is not stored correctly.")
 	// Invalid version
 	templateRecord := []byte{0, 9, 0, 40, 95, 40, 211, 236, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 24, 1, 0, 0, 3, 0, 8, 0, 4, 0, 12, 0, 4, 128, 105, 255, 255, 0, 0, 218, 21}
@@ -296,8 +296,8 @@ func TestCollectingProcess_DecodeDataRecord(t *testing.T) {
 		t.Error("Message.Set does not store data in correct format")
 	}
 	ipAddress := net.IP([]byte{1, 2, 3, 4})
-	assert.Equal(t, true, v.GetRecords()[0].ContainsInfoElement("sourceIPv4Address"))
-	sourceIPv4Address := v.GetRecords()[0].GetInfoElement("sourceIPv4Address")
+	sourceIPv4Address, exist := v.GetRecords()[0].GetInfoElementMap()["sourceIPv4Address"]
+	assert.Equal(t, true, exist)
 	assert.Equal(t, ipAddress, sourceIPv4Address.Value, "sourceIPv4Address should be decoded and stored correctly.")
 	// Malformed data record
 	dataRecord := []byte{0, 10, 0, 33, 95, 40, 212, 159, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0}

--- a/pkg/collector/tcp.go
+++ b/pkg/collector/tcp.go
@@ -68,7 +68,7 @@ func (cp *collectingProcess) handleTCPClient(conn net.Conn, wg *sync.WaitGroup) 
 				}
 				size = size - length
 				// get the message here
-				message, err := cp.decodePacket(bytes.NewBuffer(buff[0:length]))
+				message, err := cp.decodePacket(bytes.NewBuffer(buff[0:length]), address)
 				if err != nil {
 					klog.Error(err)
 					break out

--- a/pkg/collector/udp.go
+++ b/pkg/collector/udp.go
@@ -85,7 +85,7 @@ func (cp *collectingProcess) handleUDPClient(address net.Addr, wg *sync.WaitGrou
 					return
 				case packet := <-client.packetChan:
 					// get the message here
-					message, err := cp.decodePacket(packet)
+					message, err := cp.decodePacket(packet, address.String())
 					if err != nil {
 						klog.Error(err)
 						return

--- a/pkg/entities/message.go
+++ b/pkg/entities/message.go
@@ -22,12 +22,13 @@ const (
 
 // data struct of processed message
 type Message struct {
-	Version      uint16
-	BufferLength uint16
-	SeqNumber    uint32
-	ObsDomainID  uint32
-	ExportTime   uint32
-	Set          Set
+	Version       uint16
+	BufferLength  uint16
+	SeqNumber     uint32
+	ObsDomainID   uint32
+	ExportTime    uint32
+	ExportAddress string
+	Set           Set
 }
 
 // Does it need an interface?

--- a/pkg/entities/record.go
+++ b/pkg/entities/record.go
@@ -37,18 +37,18 @@ type Record interface {
 	GetBuffer() *bytes.Buffer
 	GetTemplateID() uint16
 	GetFieldCount() uint16
-	GetInfoElements() []*InfoElementWithValue
+	GetOrderedElementList() []*InfoElementWithValue
 	GetInfoElementMap() map[string]*InfoElementWithValue
 	GetMinDataRecordLen() uint16
 }
 
 type baseRecord struct {
-	buff        bytes.Buffer
-	len         uint16
-	fieldCount  uint16
-	templateID  uint16
-	elementList []*InfoElementWithValue
-	elementsMap map[string]*InfoElementWithValue
+	buff               bytes.Buffer
+	len                uint16
+	fieldCount         uint16
+	templateID         uint16
+	orderedElementList []*InfoElementWithValue
+	elementsMap        map[string]*InfoElementWithValue
 	Record
 }
 
@@ -59,12 +59,12 @@ type dataRecord struct {
 func NewDataRecord(id uint16) *dataRecord {
 	return &dataRecord{
 		&baseRecord{
-			buff:        bytes.Buffer{},
-			len:         0,
-			fieldCount:  0,
-			templateID:  id,
-			elementList: make([]*InfoElementWithValue, 0),
-			elementsMap: make(map[string]*InfoElementWithValue),
+			buff:               bytes.Buffer{},
+			len:                0,
+			fieldCount:         0,
+			templateID:         id,
+			orderedElementList: make([]*InfoElementWithValue, 0),
+			elementsMap:        make(map[string]*InfoElementWithValue),
 		},
 	}
 }
@@ -79,12 +79,12 @@ type templateRecord struct {
 func NewTemplateRecord(count uint16, id uint16) *templateRecord {
 	return &templateRecord{
 		&baseRecord{
-			buff:        bytes.Buffer{},
-			len:         0,
-			fieldCount:  count,
-			templateID:  id,
-			elementList: make([]*InfoElementWithValue, 0),
-			elementsMap: make(map[string]*InfoElementWithValue),
+			buff:               bytes.Buffer{},
+			len:                0,
+			fieldCount:         count,
+			templateID:         id,
+			orderedElementList: make([]*InfoElementWithValue, 0),
+			elementsMap:        make(map[string]*InfoElementWithValue),
 		},
 		0,
 	}
@@ -102,8 +102,8 @@ func (b *baseRecord) GetFieldCount() uint16 {
 	return b.fieldCount
 }
 
-func (d *baseRecord) GetInfoElements() []*InfoElementWithValue {
-	return d.elementList
+func (d *baseRecord) GetOrderedElementList() []*InfoElementWithValue {
+	return d.orderedElementList
 }
 
 func (d *baseRecord) GetInfoElementMap() map[string]*InfoElementWithValue {
@@ -130,7 +130,7 @@ func (d *dataRecord) AddInfoElement(element *InfoElementWithValue, isDecoding bo
 		return 0, err
 	}
 	ie := NewInfoElementWithValue(element.Element, value)
-	d.elementList = append(d.elementList, ie)
+	d.orderedElementList = append(d.orderedElementList, ie)
 	d.elementsMap[element.Element.Name] = ie
 	if err != nil {
 		return 0, err
@@ -167,7 +167,7 @@ func (t *templateRecord) AddInfoElement(element *InfoElementWithValue, isDecodin
 			return 0, err
 		}
 	}
-	t.elementList = append(t.elementList, element)
+	t.orderedElementList = append(t.orderedElementList, element)
 	t.elementsMap[element.Element.Name] = element
 	// Keep track of minimum data record length required for sanity check
 	if element.Element.Len == VariableLength {

--- a/pkg/entities/record_test.go
+++ b/pkg/entities/record_test.go
@@ -128,3 +128,35 @@ func TestAddInfoElements(t *testing.T) {
 		}
 	}
 }
+
+func TestContainsInfoElement(t *testing.T) {
+	templateRec := NewTemplateRecord(1, 256)
+	templateRec.elementsMap = make(map[string]*InfoElementWithValue)
+	ie := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+	templateRec.elementsMap["sourceIPv4Address"] = ie
+	assert.Equal(t, true, templateRec.ContainsInfoElement("sourceIPv4Address"))
+	assert.Equal(t, false, templateRec.ContainsInfoElement("destinationIPv4Address"))
+	dataRec := NewDataRecord(256)
+	dataRec.elementsMap = make(map[string]*InfoElementWithValue)
+	ie = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
+	dataRec.elementsMap["sourceIPv4Address"] = ie
+	assert.Equal(t, true, dataRec.ContainsInfoElement("sourceIPv4Address"))
+	assert.Equal(t, false, dataRec.ContainsInfoElement("destinationIPv4Address"))
+}
+
+func TestGetInfoElement(t *testing.T) {
+	templateRec := NewTemplateRecord(1, 256)
+	templateRec.elementsMap = make(map[string]*InfoElementWithValue)
+	ie := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+	templateRec.elementsMap["sourceIPv4Address"] = ie
+	assert.NotNil(t, templateRec.GetInfoElement("sourceIPv4Address"))
+	assert.Nil(t, templateRec.GetInfoElement("destinationIPv4Address"))
+
+	dataRec := NewDataRecord(256)
+	dataRec.elementsMap = make(map[string]*InfoElementWithValue)
+	ie = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
+	dataRec.elementsMap["sourceIPv4Address"] = ie
+	assert.NotNil(t, dataRec.GetInfoElement("sourceIPv4Address"))
+	assert.Equal(t, net.ParseIP("10.0.0.1"), dataRec.GetInfoElement("sourceIPv4Address").Value)
+	assert.Nil(t, dataRec.GetInfoElement("destinationIPv4Address"))
+}

--- a/pkg/entities/record_test.go
+++ b/pkg/entities/record_test.go
@@ -129,34 +129,21 @@ func TestAddInfoElements(t *testing.T) {
 	}
 }
 
-func TestContainsInfoElement(t *testing.T) {
+func TestGetInfoElementMap(t *testing.T) {
 	templateRec := NewTemplateRecord(1, 256)
 	templateRec.elementsMap = make(map[string]*InfoElementWithValue)
 	ie := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	templateRec.elementsMap["sourceIPv4Address"] = ie
-	assert.Equal(t, true, templateRec.ContainsInfoElement("sourceIPv4Address"))
-	assert.Equal(t, false, templateRec.ContainsInfoElement("destinationIPv4Address"))
+	_, exist := templateRec.GetInfoElementMap()["sourceIPv4Address"]
+	assert.Equal(t, true, exist)
+	_, exist = templateRec.GetInfoElementMap()["destinationIPv4Address"]
+	assert.Equal(t, false, exist)
 	dataRec := NewDataRecord(256)
 	dataRec.elementsMap = make(map[string]*InfoElementWithValue)
 	ie = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
 	dataRec.elementsMap["sourceIPv4Address"] = ie
-	assert.Equal(t, true, dataRec.ContainsInfoElement("sourceIPv4Address"))
-	assert.Equal(t, false, dataRec.ContainsInfoElement("destinationIPv4Address"))
-}
-
-func TestGetInfoElement(t *testing.T) {
-	templateRec := NewTemplateRecord(1, 256)
-	templateRec.elementsMap = make(map[string]*InfoElementWithValue)
-	ie := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
-	templateRec.elementsMap["sourceIPv4Address"] = ie
-	assert.NotNil(t, templateRec.GetInfoElement("sourceIPv4Address"))
-	assert.Nil(t, templateRec.GetInfoElement("destinationIPv4Address"))
-
-	dataRec := NewDataRecord(256)
-	dataRec.elementsMap = make(map[string]*InfoElementWithValue)
-	ie = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
-	dataRec.elementsMap["sourceIPv4Address"] = ie
-	assert.NotNil(t, dataRec.GetInfoElement("sourceIPv4Address"))
-	assert.Equal(t, net.ParseIP("10.0.0.1"), dataRec.GetInfoElement("sourceIPv4Address").Value)
-	assert.Nil(t, dataRec.GetInfoElement("destinationIPv4Address"))
+	infoElementWithValue, _ := dataRec.GetInfoElementMap()["sourceIPv4Address"]
+	assert.Equal(t, net.ParseIP("10.0.0.1"), infoElementWithValue.Value)
+	infoElementWithValue, _ = dataRec.GetInfoElementMap()["destinationIPv4Address"]
+	assert.Nil(t, infoElementWithValue)
 }

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -15,8 +15,10 @@ func TestAddRecordIPv4Addresses(t *testing.T) {
 	elements = append(elements, ie1, ie2)
 	set := NewSet(Template, uint16(256), true)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("sourceIPv4Address"))
-	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("destinationIPv4Address"))
+	_, exist := set.GetRecords()[0].GetInfoElementMap()["sourceIPv4Address"]
+	assert.Equal(t, true, exist)
+	_, exist = set.GetRecords()[0].GetInfoElementMap()["destinationIPv4Address"]
+	assert.Equal(t, true, exist)
 	// Test with data set
 	set = NewSet(Data, uint16(256), false)
 	elements = make([]*InfoElementWithValue, 0)
@@ -24,10 +26,10 @@ func TestAddRecordIPv4Addresses(t *testing.T) {
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("10.0.0.2"))
 	elements = append(elements, ie1, ie2)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("sourceIPv4Address"))
-	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("destinationIPv4Address"))
-	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x1}), set.GetRecords()[0].GetInfoElement("sourceIPv4Address").Value)
-	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x2}), set.GetRecords()[0].GetInfoElement("destinationIPv4Address").Value)
+	infoElementWithValue, _ := set.GetRecords()[0].GetInfoElementMap()["sourceIPv4Address"]
+	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x1}), infoElementWithValue.Value)
+	infoElementWithValue, _ = set.GetRecords()[0].GetInfoElementMap()["destinationIPv4Address"]
+	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x2}), infoElementWithValue.Value)
 }
 
 func TestAddRecordIPv6Addresses(t *testing.T) {
@@ -38,8 +40,10 @@ func TestAddRecordIPv6Addresses(t *testing.T) {
 	elements = append(elements, ie1, ie2)
 	set := NewSet(Template, uint16(256), true)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("sourceIPv6Address"))
-	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("destinationIPv6Address"))
+	_, exist := set.GetRecords()[0].GetInfoElementMap()["sourceIPv6Address"]
+	assert.Equal(t, true, exist)
+	_, exist = set.GetRecords()[0].GetInfoElementMap()["destinationIPv6Address"]
+	assert.Equal(t, true, exist)
 	// Test with data set
 	set = NewSet(Data, uint16(256), false)
 	elements = make([]*InfoElementWithValue, 0)
@@ -47,10 +51,10 @@ func TestAddRecordIPv6Addresses(t *testing.T) {
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
 	elements = append(elements, ie1, ie2)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("sourceIPv6Address"))
-	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("destinationIPv6Address"))
-	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}), set.GetRecords()[0].GetInfoElement("sourceIPv6Address").Value)
-	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfc}), set.GetRecords()[0].GetInfoElement("destinationIPv6Address").Value)
+	infoElementWithValue, _ := set.GetRecords()[0].GetInfoElementMap()["sourceIPv6Address"]
+	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}), infoElementWithValue.Value)
+	infoElementWithValue, _ = set.GetRecords()[0].GetInfoElementMap()["destinationIPv6Address"]
+	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfc}), infoElementWithValue.Value)
 }
 
 func TestGetSetType(t *testing.T) {

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -15,8 +15,8 @@ func TestAddRecordIPv4Addresses(t *testing.T) {
 	elements = append(elements, ie1, ie2)
 	set := NewSet(Template, uint16(256), true)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, ie1, set.GetRecords()[0].GetInfoElements()[0])
-	assert.Equal(t, ie2, set.GetRecords()[0].GetInfoElements()[1])
+	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("sourceIPv4Address"))
+	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("destinationIPv4Address"))
 	// Test with data set
 	set = NewSet(Data, uint16(256), false)
 	elements = make([]*InfoElementWithValue, 0)
@@ -24,8 +24,10 @@ func TestAddRecordIPv4Addresses(t *testing.T) {
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("10.0.0.2"))
 	elements = append(elements, ie1, ie2)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x1}), set.GetRecords()[0].GetInfoElements()[0].Value)
-	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x2}), set.GetRecords()[0].GetInfoElements()[1].Value)
+	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("sourceIPv4Address"))
+	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("destinationIPv4Address"))
+	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x1}), set.GetRecords()[0].GetInfoElement("sourceIPv4Address").Value)
+	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x2}), set.GetRecords()[0].GetInfoElement("destinationIPv4Address").Value)
 }
 
 func TestAddRecordIPv6Addresses(t *testing.T) {
@@ -36,8 +38,8 @@ func TestAddRecordIPv6Addresses(t *testing.T) {
 	elements = append(elements, ie1, ie2)
 	set := NewSet(Template, uint16(256), true)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, ie1, set.GetRecords()[0].GetInfoElements()[0])
-	assert.Equal(t, ie2, set.GetRecords()[0].GetInfoElements()[1])
+	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("sourceIPv6Address"))
+	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("destinationIPv6Address"))
 	// Test with data set
 	set = NewSet(Data, uint16(256), false)
 	elements = make([]*InfoElementWithValue, 0)
@@ -45,8 +47,10 @@ func TestAddRecordIPv6Addresses(t *testing.T) {
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
 	elements = append(elements, ie1, ie2)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}), set.GetRecords()[0].GetInfoElements()[0].Value)
-	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfc}), set.GetRecords()[0].GetInfoElements()[1].Value)
+	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("sourceIPv6Address"))
+	assert.Equal(t, true, set.GetRecords()[0].ContainsInfoElement("destinationIPv6Address"))
+	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}), set.GetRecords()[0].GetInfoElement("sourceIPv6Address").Value)
+	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfc}), set.GetRecords()[0].GetInfoElement("destinationIPv6Address").Value)
 }
 
 func TestGetSetType(t *testing.T) {

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -83,7 +83,7 @@ func TestGetRecords(t *testing.T) {
 	elements = append(elements, ie1, ie2)
 	set := NewSet(Template, uint16(256), true)
 	set.AddRecord(elements, 256)
-	assert.Equal(t, 2, len(set.GetRecords()[0].GetInfoElements()))
+	assert.Equal(t, 2, len(set.GetRecords()[0].GetOrderedElementList()))
 }
 
 func TestGetNumberOfRecords(t *testing.T) {

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -63,6 +63,20 @@ func (mr *MockRecordMockRecorder) AddInfoElement(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInfoElement", reflect.TypeOf((*MockRecord)(nil).AddInfoElement), arg0, arg1)
 }
 
+// ContainsInfoElement mocks base method
+func (m *MockRecord) ContainsInfoElement(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainsInfoElement", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ContainsInfoElement indicates an expected call of ContainsInfoElement
+func (mr *MockRecordMockRecorder) ContainsInfoElement(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsInfoElement", reflect.TypeOf((*MockRecord)(nil).ContainsInfoElement), arg0)
+}
+
 // GetBuffer mocks base method
 func (m *MockRecord) GetBuffer() *bytes.Buffer {
 	m.ctrl.T.Helper()
@@ -89,6 +103,20 @@ func (m *MockRecord) GetFieldCount() uint16 {
 func (mr *MockRecordMockRecorder) GetFieldCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFieldCount", reflect.TypeOf((*MockRecord)(nil).GetFieldCount))
+}
+
+// GetInfoElement mocks base method
+func (m *MockRecord) GetInfoElement(arg0 string) *entities.InfoElementWithValue {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInfoElement", arg0)
+	ret0, _ := ret[0].(*entities.InfoElementWithValue)
+	return ret0
+}
+
+// GetInfoElement indicates an expected call of GetInfoElement
+func (mr *MockRecordMockRecorder) GetInfoElement(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfoElement", reflect.TypeOf((*MockRecord)(nil).GetInfoElement), arg0)
 }
 
 // GetInfoElements mocks base method

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -63,20 +63,6 @@ func (mr *MockRecordMockRecorder) AddInfoElement(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInfoElement", reflect.TypeOf((*MockRecord)(nil).AddInfoElement), arg0, arg1)
 }
 
-// ContainsInfoElement mocks base method
-func (m *MockRecord) ContainsInfoElement(arg0 string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainsInfoElement", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// ContainsInfoElement indicates an expected call of ContainsInfoElement
-func (mr *MockRecordMockRecorder) ContainsInfoElement(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsInfoElement", reflect.TypeOf((*MockRecord)(nil).ContainsInfoElement), arg0)
-}
-
 // GetBuffer mocks base method
 func (m *MockRecord) GetBuffer() *bytes.Buffer {
 	m.ctrl.T.Helper()
@@ -105,18 +91,18 @@ func (mr *MockRecordMockRecorder) GetFieldCount() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFieldCount", reflect.TypeOf((*MockRecord)(nil).GetFieldCount))
 }
 
-// GetInfoElement mocks base method
-func (m *MockRecord) GetInfoElement(arg0 string) *entities.InfoElementWithValue {
+// GetInfoElementMap mocks base method
+func (m *MockRecord) GetInfoElementMap() map[string]*entities.InfoElementWithValue {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInfoElement", arg0)
-	ret0, _ := ret[0].(*entities.InfoElementWithValue)
+	ret := m.ctrl.Call(m, "GetInfoElementMap")
+	ret0, _ := ret[0].(map[string]*entities.InfoElementWithValue)
 	return ret0
 }
 
-// GetInfoElement indicates an expected call of GetInfoElement
-func (mr *MockRecordMockRecorder) GetInfoElement(arg0 interface{}) *gomock.Call {
+// GetInfoElementMap indicates an expected call of GetInfoElementMap
+func (mr *MockRecordMockRecorder) GetInfoElementMap() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfoElement", reflect.TypeOf((*MockRecord)(nil).GetInfoElement), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfoElementMap", reflect.TypeOf((*MockRecord)(nil).GetInfoElementMap))
 }
 
 // GetInfoElements mocks base method

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -105,20 +105,6 @@ func (mr *MockRecordMockRecorder) GetInfoElementMap() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfoElementMap", reflect.TypeOf((*MockRecord)(nil).GetInfoElementMap))
 }
 
-// GetInfoElements mocks base method
-func (m *MockRecord) GetInfoElements() []*entities.InfoElementWithValue {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInfoElements")
-	ret0, _ := ret[0].([]*entities.InfoElementWithValue)
-	return ret0
-}
-
-// GetInfoElements indicates an expected call of GetInfoElements
-func (mr *MockRecordMockRecorder) GetInfoElements() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfoElements", reflect.TypeOf((*MockRecord)(nil).GetInfoElements))
-}
-
 // GetMinDataRecordLen mocks base method
 func (m *MockRecord) GetMinDataRecordLen() uint16 {
 	m.ctrl.T.Helper()
@@ -131,6 +117,20 @@ func (m *MockRecord) GetMinDataRecordLen() uint16 {
 func (mr *MockRecordMockRecorder) GetMinDataRecordLen() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinDataRecordLen", reflect.TypeOf((*MockRecord)(nil).GetMinDataRecordLen))
+}
+
+// GetOrderedElementList mocks base method
+func (m *MockRecord) GetOrderedElementList() []*entities.InfoElementWithValue {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrderedElementList")
+	ret0, _ := ret[0].([]*entities.InfoElementWithValue)
+	return ret0
+}
+
+// GetOrderedElementList indicates an expected call of GetOrderedElementList
+func (mr *MockRecordMockRecorder) GetOrderedElementList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrderedElementList", reflect.TypeOf((*MockRecord)(nil).GetOrderedElementList))
 }
 
 // GetTemplateID mocks base method

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -101,7 +101,7 @@ func InitExportingProcess(collectorAddr net.Addr, obsID uint32, tempRefTimeout u
 func (ep *ExportingProcess) AddSetAndSendMsg(setType entities.ContentType, set entities.Set) (int, error) {
 	for _, record := range set.GetRecords() {
 		if setType == entities.Template {
-			ep.updateTemplate(record.GetTemplateID(), record.GetInfoElements(), record.GetMinDataRecordLen())
+			ep.updateTemplate(record.GetTemplateID(), record.GetOrderedElementList(), record.GetMinDataRecordLen())
 		} else if setType == entities.Data {
 			err := ep.dataRecSanityCheck(record)
 			if err != nil {

--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -14,11 +14,11 @@ type aggregation struct {
 	tupleRecordMap map[Tuple][]entities.Record
 	// tupleRecordLock allows multiple readers or one writer at the same time
 	tupleRecordLock sync.RWMutex
-	// workerPool is for storing worker channels to process message
+	// workerPool is for storing worker channels to process the messages
 	workerPool chan chan *entities.Message
-	// messageChan is the channel to receive message
+	// messageChan is the channel to receive the message
 	messageChan chan *entities.Message
-	// workerNum is the number of workers to process message
+	// workerNum is the number of workers to process the messages
 	workerNum int
 	// workerList is the list of workers
 	workerList []*worker

--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -1,0 +1,146 @@
+package intermediate
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/vmware/go-ipfix/pkg/entities"
+)
+
+type aggregation struct {
+	// tupleRecordMap maps each connection with its records
+	tupleRecordMap map[Tuple][]entities.Record
+	// tupleRecordLock allows multiple readers or one writer at the same time
+	tupleRecordLock sync.RWMutex
+	// workerPool is for exchanging worker channels to process message
+	workerPool chan chan *entities.Message
+	// messageChan is the channel to receive message
+	messageChan chan *entities.Message
+	// workerNum is the number of workers to process message
+	workerNum int
+	// workerList is the list of workers
+	workerList []*worker
+}
+
+type Tuple struct {
+	// SourceAddress is the encoded format of sourceIPv4Address
+	SourceAddress uint32
+	// DestinationAddress is the encoded format of destinationIPv4Address
+	DestinationAddress uint32
+	Protocol           uint8
+	SourcePort         uint16
+	DestinationPort    uint16
+}
+
+func InitAggregationProcess(messageChan chan *entities.Message, workerNum int) (*aggregation, error) {
+	if messageChan == nil {
+		return nil, fmt.Errorf("Cannot create aggregation process without message channel.")
+	} else if workerNum <= 0 {
+		return nil, fmt.Errorf("Worker number cannot be <= 0.")
+	}
+	return &aggregation{
+		make(map[Tuple][]entities.Record),
+		sync.RWMutex{},
+		make(chan chan *entities.Message),
+		messageChan,
+		workerNum,
+		make([]*worker, 0),
+	}, nil
+}
+
+func (a *aggregation) Start() {
+	for i := 0; i < a.workerNum; i++ {
+		w := createWorker(i, a.workerPool, a.AggregateMsgBy5Tuple)
+		w.start()
+		a.workerList = append(a.workerList, w)
+	}
+	for message := range a.messageChan {
+		channel := <-a.workerPool
+		channel <- message
+	}
+}
+
+func (a *aggregation) Stop() {
+	for _, worker := range a.workerList {
+		worker.stop()
+	}
+}
+
+// AggregateMsgBy5Tuple gets 5-tuple info from records in message and stores in cache
+func (a *aggregation) AggregateMsgBy5Tuple(message *entities.Message) error {
+	if message.Set.GetSetType() == entities.Template { // skip template records
+		return nil
+	}
+	records := message.Set.GetRecords()
+	a.tupleRecordLock.Lock()
+	defer a.tupleRecordLock.Unlock()
+	for _, record := range records {
+		tuple, err := getTupleFromRecord(record)
+		if err != nil {
+			return err
+		}
+		if _, exist := a.tupleRecordMap[tuple]; !exist {
+			a.tupleRecordMap[tuple] = make([]entities.Record, 0)
+		}
+		a.tupleRecordMap[tuple] = append(a.tupleRecordMap[tuple], record)
+	}
+	return nil
+}
+
+func (a *aggregation) GetTupleRecordMap() map[Tuple][]entities.Record {
+	a.tupleRecordLock.RLock()
+	defer a.tupleRecordLock.RUnlock()
+	return a.tupleRecordMap
+}
+
+// getTupleFromRecord returns 5-tuple from data record
+func getTupleFromRecord(record entities.Record) (Tuple, error) {
+	var srcIP, dstIP uint32
+	var srcPort, dstPort uint16
+	var proto uint8
+	// count is for checking whether 5-tuple is fully collected
+	count := 0
+	for _, infoElementWithValue := range record.GetInfoElements() {
+		if infoElementWithValue.Element.Name == "sourceIPv4Address" {
+			addr, ok := infoElementWithValue.Value.([]byte)
+			if !ok {
+				return Tuple{}, fmt.Errorf("sourceIPv4Address is not in correct format.")
+			}
+			srcIP = binary.BigEndian.Uint32(addr)
+			count++
+		} else if infoElementWithValue.Element.Name == "destinationIPv4Address" {
+			addr, ok := infoElementWithValue.Value.([]byte)
+			if !ok {
+				return Tuple{}, fmt.Errorf("destinationIPv4Address is not in correct format.")
+			}
+			dstIP = binary.BigEndian.Uint32(addr)
+			count++
+		} else if infoElementWithValue.Element.Name == "sourceTransportPort" {
+			v, ok := infoElementWithValue.Value.(uint16)
+			if !ok {
+				return Tuple{}, fmt.Errorf("sourceTransportPort is not in correct format.")
+			}
+			srcPort = v
+			count++
+		} else if infoElementWithValue.Element.Name == "destinationTransportPort" {
+			v, ok := infoElementWithValue.Value.(uint16)
+			if !ok {
+				return Tuple{}, fmt.Errorf("destinationTransportPort is not in correct format.")
+			}
+			dstPort = v
+			count++
+		} else if infoElementWithValue.Element.Name == "protocolIdentifier" {
+			v, ok := infoElementWithValue.Value.(uint8)
+			if !ok {
+				return Tuple{}, fmt.Errorf("protocolIdentifier is not in correct format.")
+			}
+			proto = v
+			count++
+		}
+	}
+	if count != 5 {
+		return Tuple{}, fmt.Errorf("Missing 5-tuple value(s) in the record.")
+	}
+	return Tuple{srcIP, dstIP, proto, srcPort, dstPort}, nil
+}

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/registry"
@@ -21,7 +22,11 @@ func createMsgwithTemplateSet() *entities.Message {
 	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), nil)
 	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), nil)
 	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), nil)
-	elements = append(elements, ie1, ie2, ie3, ie4, ie5)
+	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, 55829, 65535), nil)
+	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, 55829, 65535), nil)
+	ie8 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIP", 106, 18, 55829, 4), nil)
+	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, 55829, 2), nil)
+	elements = append(elements, ie1, ie2, ie3, ie4, ie5, ie6, ie7, ie8, ie9)
 	set.AddRecord(elements, 256)
 	return &entities.Message{
 		Version:       10,
@@ -34,21 +39,68 @@ func createMsgwithTemplateSet() *entities.Message {
 	}
 }
 
-func createMsgwithDataSet() *entities.Message {
+func createMsgwithDataSet1() *entities.Message {
 	set := entities.NewSet(entities.Data, 256, true)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	srcPort := new(bytes.Buffer)
 	dstPort := new(bytes.Buffer)
 	proto := new(bytes.Buffer)
+	svcPort := new(bytes.Buffer)
+	srcPod := new(bytes.Buffer)
+	dstPod := new(bytes.Buffer)
 	util.Encode(srcPort, binary.BigEndian, uint16(1234))
 	util.Encode(dstPort, binary.BigEndian, uint16(5678))
 	util.Encode(proto, binary.BigEndian, uint8(6))
+	util.Encode(svcPort, binary.BigEndian, uint16(4739))
+	srcPod.WriteString("pod1")
+	dstPod.WriteString("")
 	ie1 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), bytes.NewBuffer([]byte{10, 0, 0, 1}))
 	ie2 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), bytes.NewBuffer([]byte{10, 0, 0, 2}))
 	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), srcPort)
 	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), dstPort)
 	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), proto)
-	elements = append(elements, ie1, ie2, ie3, ie4, ie5)
+	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, 55829, 65535), srcPod)
+	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, 55829, 65535), dstPod)
+	ie8 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIP", 106, 18, 55829, 4), bytes.NewBuffer([]byte{192, 168, 0, 1}))
+	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, 55829, 2), svcPort)
+	elements = append(elements, ie1, ie2, ie3, ie4, ie5, ie6, ie7, ie8, ie9)
+	set.AddRecord(elements, 256)
+	return &entities.Message{
+		Version:       10,
+		BufferLength:  32,
+		SeqNumber:     1,
+		ObsDomainID:   uint32(1234),
+		ExportTime:    0,
+		ExportAddress: "127.0.0.1",
+		Set:           set,
+	}
+}
+
+func createMsgwithDataSet2() *entities.Message {
+	set := entities.NewSet(entities.Data, 256, true)
+	elements := make([]*entities.InfoElementWithValue, 0)
+	srcPort := new(bytes.Buffer)
+	dstPort := new(bytes.Buffer)
+	proto := new(bytes.Buffer)
+	svcPort := new(bytes.Buffer)
+	srcPod := new(bytes.Buffer)
+	dstPod := new(bytes.Buffer)
+	util.Encode(srcPort, binary.BigEndian, uint16(1234))
+	util.Encode(dstPort, binary.BigEndian, uint16(5678))
+	util.Encode(proto, binary.BigEndian, uint8(6))
+	util.Encode(svcPort, binary.BigEndian, uint16(4739))
+	srcPod.WriteString("")
+	dstPod.WriteString("pod2")
+	ie1 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), bytes.NewBuffer([]byte{10, 0, 0, 1}))
+	ie2 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), bytes.NewBuffer([]byte{10, 0, 0, 2}))
+	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), srcPort)
+	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), dstPort)
+	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), proto)
+	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, 55829, 65535), srcPod)
+	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, 55829, 65535), dstPod)
+	ie8 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIP", 106, 18, 55829, 4), nil)
+	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, 55829, 2), nil)
+	elements = append(elements, ie1, ie2, ie3, ie4, ie5, ie6, ie7, ie8, ie9)
 	set.AddRecord(elements, 256)
 	return &entities.Message{
 		Version:       10,
@@ -85,7 +137,7 @@ func TestAggregateMsgBy5Tuple(t *testing.T) {
 	aggregationProcess.AggregateMsgBy5Tuple(message)
 	assert.Empty(t, aggregationProcess.GetTupleRecordMap())
 	// Data records should be processed and stored with corresponding tuple
-	message = createMsgwithDataSet()
+	message = createMsgwithDataSet1()
 	aggregationProcess.AggregateMsgBy5Tuple(message)
 	assert.NotEmpty(t, aggregationProcess.GetTupleRecordMap())
 	for tuple, records := range aggregationProcess.GetTupleRecordMap() {
@@ -101,7 +153,7 @@ func TestAggregateMsgBy5Tuple(t *testing.T) {
 func TestAggregationProcess(t *testing.T) {
 	messageChan := make(chan *entities.Message)
 	aggregationProcess, _ := InitAggregationProcess(messageChan, 2)
-	dataMsg := createMsgwithDataSet()
+	dataMsg := createMsgwithDataSet1()
 	go func() {
 		messageChan <- createMsgwithTemplateSet()
 		time.Sleep(time.Second)
@@ -123,14 +175,34 @@ func TestAddOriginalExporterInfo(t *testing.T) {
 	message := createMsgwithTemplateSet()
 	addOriginalExporterInfo(message)
 	record := message.Set.GetRecords()[0]
-	assert.Equal(t, "originalExporterIPv4Address", record.GetInfoElements()[5].Element.Name)
-	assert.Equal(t, "originalObservationDomainId", record.GetInfoElements()[6].Element.Name)
+	assert.Equal(t, "originalExporterIPv4Address", record.GetInfoElements()[9].Element.Name)
+	assert.Equal(t, "originalObservationDomainId", record.GetInfoElements()[10].Element.Name)
 	// Test message with data set
-	message = createMsgwithDataSet()
+	message = createMsgwithDataSet1()
 	addOriginalExporterInfo(message)
 	record = message.Set.GetRecords()[0]
-	assert.Equal(t, "originalExporterIPv4Address", record.GetInfoElements()[5].Element.Name)
-	assert.Equal(t, uint32(2130706433), record.GetInfoElements()[5].Value)
-	assert.Equal(t, "originalObservationDomainId", record.GetInfoElements()[6].Element.Name)
-	assert.Equal(t, uint32(1234), record.GetInfoElements()[6].Value)
+	klog.Info(record.GetInfoElements())
+	assert.Equal(t, "originalExporterIPv4Address", record.GetInfoElements()[9].Element.Name)
+	assert.Equal(t, uint32(2130706433), record.GetInfoElements()[9].Value)
+	assert.Equal(t, "originalObservationDomainId", record.GetInfoElements()[10].Element.Name)
+	assert.Equal(t, uint32(1234), record.GetInfoElements()[10].Value)
+}
+
+func TestCorrelateRecords(t *testing.T) {
+	registry.LoadRegistry()
+	messageChan := make(chan *entities.Message)
+	aggregationProcess, _ := InitAggregationProcess(messageChan, 2)
+	message1 := createMsgwithDataSet1()
+	message2 := createMsgwithDataSet2()
+	aggregationProcess.AggregateMsgBy5Tuple(message1)
+	aggregationProcess.AggregateMsgBy5Tuple(message2)
+	assert.Equal(t, 1, len(aggregationProcess.GetTupleRecordMap()))
+	for _, records := range aggregationProcess.GetTupleRecordMap() {
+		assert.Equal(t, 1, len(records))
+		elements := records[0].GetInfoElements()
+		assert.Equal(t, "pod1", elements[5].Value)
+		assert.Equal(t, "pod2", elements[6].Value)
+		assert.Equal(t, []byte{192, 168, 0, 1}, elements[7].Value)
+		assert.Equal(t, uint16(4739), elements[8].Value)
+	}
 }

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
+	"github.com/vmware/go-ipfix/pkg/registry"
 	"github.com/vmware/go-ipfix/pkg/util"
 )
 
@@ -114,4 +115,22 @@ func TestAggregationProcess(t *testing.T) {
 		167772161, 167772162, 6, 1234, 5678,
 	}
 	assert.NotNil(t, aggregationProcess.GetTupleRecordMap()[tuple])
+}
+
+func TestAddOriginalExporterInfo(t *testing.T) {
+	registry.LoadRegistry()
+	// Test message with template set
+	message := createMsgwithTemplateSet()
+	addOriginalExporterInfo(message)
+	record := message.Set.GetRecords()[0]
+	assert.Equal(t, "originalExporterIPv4Address", record.GetInfoElements()[5].Element.Name)
+	assert.Equal(t, "originalObservationDomainId", record.GetInfoElements()[6].Element.Name)
+	// Test message with data set
+	message = createMsgwithDataSet()
+	addOriginalExporterInfo(message)
+	record = message.Set.GetRecords()[0]
+	assert.Equal(t, "originalExporterIPv4Address", record.GetInfoElements()[5].Element.Name)
+	assert.Equal(t, uint32(2130706433), record.GetInfoElements()[5].Value)
+	assert.Equal(t, "originalObservationDomainId", record.GetInfoElements()[6].Element.Name)
+	assert.Equal(t, uint32(1234), record.GetInfoElements()[6].Value)
 }

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -1,0 +1,117 @@
+package intermediate
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/go-ipfix/pkg/entities"
+	"github.com/vmware/go-ipfix/pkg/util"
+)
+
+func createMsgwithTemplateSet() *entities.Message {
+	set := entities.NewSet(entities.Template, 256, true)
+	elements := make([]*entities.InfoElementWithValue, 0)
+	ie1 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+	ie2 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
+	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), nil)
+	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), nil)
+	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), nil)
+	elements = append(elements, ie1, ie2, ie3, ie4, ie5)
+	set.AddRecord(elements, 256)
+	return &entities.Message{
+		Version:       10,
+		BufferLength:  40,
+		SeqNumber:     1,
+		ObsDomainID:   5678,
+		ExportTime:    0,
+		ExportAddress: "127.0.0.1",
+		Set:           set,
+	}
+}
+
+func createMsgwithDataSet() *entities.Message {
+	set := entities.NewSet(entities.Data, 256, true)
+	elements := make([]*entities.InfoElementWithValue, 0)
+	srcPort := new(bytes.Buffer)
+	dstPort := new(bytes.Buffer)
+	proto := new(bytes.Buffer)
+	util.Encode(srcPort, binary.BigEndian, uint16(1234))
+	util.Encode(dstPort, binary.BigEndian, uint16(5678))
+	util.Encode(proto, binary.BigEndian, uint8(6))
+	ie1 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), bytes.NewBuffer([]byte{10, 0, 0, 1}))
+	ie2 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), bytes.NewBuffer([]byte{10, 0, 0, 2}))
+	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), srcPort)
+	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), dstPort)
+	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), proto)
+	elements = append(elements, ie1, ie2, ie3, ie4, ie5)
+	set.AddRecord(elements, 256)
+	return &entities.Message{
+		Version:       10,
+		BufferLength:  32,
+		SeqNumber:     1,
+		ObsDomainID:   uint32(1234),
+		ExportTime:    0,
+		ExportAddress: "127.0.0.1",
+		Set:           set,
+	}
+}
+
+func TestInitAggregationProcess(t *testing.T) {
+	aggregationProcess, err := InitAggregationProcess(nil, 2)
+	assert.NotNil(t, err)
+	assert.Nil(t, aggregationProcess)
+	messageChan := make(chan *entities.Message)
+	aggregationProcess, err = InitAggregationProcess(messageChan, 2)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, aggregationProcess.workerNum)
+}
+
+func TestGetTupleRecordMap(t *testing.T) {
+	messageChan := make(chan *entities.Message)
+	aggregationProcess, _ := InitAggregationProcess(messageChan, 2)
+	assert.Equal(t, aggregationProcess.tupleRecordMap, aggregationProcess.GetTupleRecordMap())
+}
+
+func TestAggregateMsgBy5Tuple(t *testing.T) {
+	messageChan := make(chan *entities.Message)
+	aggregationProcess, _ := InitAggregationProcess(messageChan, 2)
+	// Template records should be ignored
+	message := createMsgwithTemplateSet()
+	aggregationProcess.AggregateMsgBy5Tuple(message)
+	assert.Empty(t, aggregationProcess.GetTupleRecordMap())
+	// Data records should be processed and stored with corresponding tuple
+	message = createMsgwithDataSet()
+	aggregationProcess.AggregateMsgBy5Tuple(message)
+	assert.NotEmpty(t, aggregationProcess.GetTupleRecordMap())
+	for tuple, records := range aggregationProcess.GetTupleRecordMap() {
+		assert.Equal(t, tuple.SourceAddress, uint32(167772161))
+		assert.Equal(t, tuple.DestinationAddress, uint32(167772162))
+		assert.Equal(t, tuple.SourcePort, uint16(1234))
+		assert.Equal(t, tuple.DestinationPort, uint16(5678))
+		assert.Equal(t, tuple.Protocol, uint8(6))
+		assert.Equal(t, message.Set.GetRecords(), records)
+	}
+}
+
+func TestAggregationProcess(t *testing.T) {
+	messageChan := make(chan *entities.Message)
+	aggregationProcess, _ := InitAggregationProcess(messageChan, 2)
+	dataMsg := createMsgwithDataSet()
+	go func() {
+		messageChan <- createMsgwithTemplateSet()
+		time.Sleep(time.Second)
+		messageChan <- dataMsg
+		time.Sleep(time.Second)
+		close(messageChan)
+		aggregationProcess.Stop()
+	}()
+	aggregationProcess.Start()
+	tuple := Tuple{
+		167772161, 167772162, 6, 1234, 5678,
+	}
+	assert.NotNil(t, aggregationProcess.GetTupleRecordMap()[tuple])
+}

--- a/pkg/intermediate/worker.go
+++ b/pkg/intermediate/worker.go
@@ -1,0 +1,47 @@
+package intermediate
+
+import (
+	"k8s.io/klog"
+
+	"github.com/vmware/go-ipfix/pkg/entities"
+)
+
+type worker struct {
+	id          int
+	workerPool  chan chan *entities.Message
+	messageChan chan *entities.Message
+	errChan     chan bool
+	job         func(*entities.Message) error
+}
+
+func createWorker(id int, wp chan chan *entities.Message, job func(*entities.Message) error) *worker {
+	return &worker{
+		id,
+		wp,
+		make(chan *entities.Message),
+		make(chan bool),
+		job,
+	}
+}
+
+func (w *worker) start() {
+	go func() {
+		for {
+			select {
+			case <-w.errChan:
+				break
+			case w.workerPool <- w.messageChan:
+				message := <-w.messageChan
+				err := w.job(message)
+				if err != nil {
+					klog.Error(err)
+				}
+				klog.V(4).Info(message)
+			}
+		}
+	}()
+}
+
+func (w *worker) stop() {
+	w.errChan <- true
+}

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -28,7 +28,7 @@ func TestCollectorToIntermediate(t *testing.T) {
 		t.Error(err)
 	}
 	// Initialize aggregation process and collecting process
-	cp, _ := collector.InitCollectingProcess(address, 1024, 0, true)
+	cp, _ := collector.InitCollectingProcess(address, 1024, 0)
 	ap, _ := intermediate.InitAggregationProcess(cp.GetMsgChan(), 2, fields)
 
 	go func() {
@@ -58,7 +58,7 @@ func TestCollectorToIntermediate(t *testing.T) {
 	assert.NotNil(t, ap.GetTupleRecordMap()[tuple])
 	assert.Equal(t, 1, len(ap.GetTupleRecordMap()[tuple]), "Aggregation process should correlate data record and only store one record.")
 	record := ap.GetTupleRecordMap()[tuple]
-	elements := record[0].GetInfoElements()
+	elements := record[0].GetOrderedElementList()
 	assert.Equal(t, "pod1", elements[5].Value)
 	assert.Equal(t, "pod2", record[0].GetInfoElementMap()["destinationPodName"].Value, "Aggregation process should correlate and fill corresponding fields.")
 	assert.Equal(t, 11, len(elements), "There should be two more fields for exporter information in the record.")

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware/go-ipfix/pkg/collector"
-	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/intermediate"
 	"github.com/vmware/go-ipfix/pkg/registry"
 )
@@ -18,14 +17,13 @@ var dataPacket = []byte{0, 10, 0, 33, 95, 140, 234, 81, 0, 0, 0, 0, 0, 0, 0, 1, 
 
 func TestCollectorToIntermediate(t *testing.T) {
 	registry.LoadRegistry()
-	messageChan := make(chan *entities.Message)
 	address, err := net.ResolveUDPAddr("udp", "0.0.0.0:4739")
 	if err != nil {
 		t.Error(err)
 	}
 	// Initialize aggregation process and collecting process
-	ap, _ := intermediate.InitAggregationProcess(messageChan, 2)
-	cp, _ := collector.InitCollectingProcess(address, 1024, 0, messageChan)
+	cp, _ := collector.InitCollectingProcess(address, 1024, 0, true)
+	ap, _ := intermediate.InitAggregationProcess(cp.GetMsgChan(), 2)
 
 	go func() {
 		time.Sleep(time.Second)

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -49,7 +49,7 @@ func TestCollectorToIntermediate(t *testing.T) {
 	}()
 	cp.Start()
 	assert.Equal(t, 1, len(ap.GetTupleRecordMap()), "Aggregation process should store the data record to map with corresponding tuple.")
-	tuple := intermediate.Tuple{SourceAddress: [16]byte{10: 255, 11: 255, 12: 1, 13: 2, 14: 3, 15: 4}, DestinationAddress: [16]byte{10: 255, 11: 255, 12: 5, 13: 6, 14: 7, 15: 8}, Protocol: 6, SourcePort: 1234, DestinationPort: 5678}
+	tuple := intermediate.Tuple{SourceAddress: "1.2.3.4", DestinationAddress: "5.6.7.8", Protocol: 6, SourcePort: 1234, DestinationPort: 5678}
 	assert.NotNil(t, ap.GetTupleRecordMap()[tuple])
 	assert.Equal(t, 1, len(ap.GetTupleRecordMap()[tuple]), "Aggregation process should correlate data record and only store one record.")
 	record := ap.GetTupleRecordMap()[tuple]

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vmware/go-ipfix/pkg/registry"
 )
 
-var templatePacket = []byte{0, 10, 0, 76, 95, 154, 84, 121, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 60, 1, 0, 0, 9, 0, 8, 0, 4, 0, 12, 0, 4, 0, 7, 0, 2, 0, 11, 0, 2, 0, 4, 0, 1, 128, 101, 255, 255, 0, 0, 218, 21, 128, 103, 255, 255, 0, 0, 218, 21, 128, 106, 0, 4, 0, 0, 218, 21, 128, 107, 0, 2, 0, 0, 218, 21}
+var templatePacket = []byte{0, 10, 0, 76, 95, 154, 84, 121, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 60, 1, 0, 0, 9, 0, 8, 0, 4, 0, 12, 0, 4, 0, 7, 0, 2, 0, 11, 0, 2, 0, 4, 0, 1, 128, 101, 255, 255, 0, 0, 220, 186, 128, 103, 255, 255, 0, 0, 220, 186, 128, 106, 0, 4, 0, 0, 220, 186, 128, 107, 0, 2, 0, 0, 220, 186}
 var dataPacket1 = []byte{0, 10, 0, 45, 95, 154, 80, 113, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 29, 1, 2, 3, 4, 5, 6, 7, 8, 4, 210, 22, 46, 6, 4, 112, 111, 100, 49, 0, 192, 168, 0, 1, 18, 131}
 var dataPacket2 = []byte{0, 10, 0, 45, 95, 154, 82, 114, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 29, 1, 2, 3, 4, 5, 6, 7, 8, 4, 210, 22, 46, 6, 0, 4, 112, 111, 100, 50, 0, 0, 0, 0, 0, 0}
 
@@ -49,13 +49,13 @@ func TestCollectorToIntermediate(t *testing.T) {
 	}()
 	cp.Start()
 	assert.Equal(t, 1, len(ap.GetTupleRecordMap()), "Aggregation process should store the data record to map with corresponding tuple.")
-	tuple := intermediate.Tuple{SourceAddress: 16909060, DestinationAddress: 84281096, Protocol: 6, SourcePort: 1234, DestinationPort: 5678}
+	tuple := intermediate.Tuple{SourceAddress: [16]byte{10: 255, 11: 255, 12: 1, 13: 2, 14: 3, 15: 4}, DestinationAddress: [16]byte{10: 255, 11: 255, 12: 5, 13: 6, 14: 7, 15: 8}, Protocol: 6, SourcePort: 1234, DestinationPort: 5678}
 	assert.NotNil(t, ap.GetTupleRecordMap()[tuple])
 	assert.Equal(t, 1, len(ap.GetTupleRecordMap()[tuple]), "Aggregation process should correlate data record and only store one record.")
 	record := ap.GetTupleRecordMap()[tuple]
 	elements := record[0].GetInfoElements()
 	assert.Equal(t, "pod1", elements[5].Value)
-	assert.Equal(t, "pod2", elements[6].Value, "Aggregation process should correlate and fill corresponding fields.")
+	assert.Equal(t, "pod2", record[0].GetInfoElement("destinationPodName").Value, "Aggregation process should correlate and fill corresponding fields.")
 	assert.Equal(t, 11, len(elements), "There should be two more fields for exporter information in the record.")
-	assert.Equal(t, uint32(1), elements[10].Value, "originalObservationDomainId should be added correctly in record.")
+	assert.Equal(t, uint32(1), record[0].GetInfoElement("originalObservationDomainId").Value, "originalObservationDomainId should be added correctly in record.")
 }

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/go-ipfix/pkg/collector"
+	"github.com/vmware/go-ipfix/pkg/entities"
+	"github.com/vmware/go-ipfix/pkg/intermediate"
+	"github.com/vmware/go-ipfix/pkg/registry"
+)
+
+var templatePacket = []byte{0, 10, 0, 44, 95, 140, 234, 80, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 28, 1, 0, 0, 5, 0, 8, 0, 4, 0, 12, 0, 4, 0, 7, 0, 2, 0, 11, 0, 2, 0, 4, 0, 1}
+var dataPacket = []byte{0, 10, 0, 33, 95, 140, 234, 81, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 17, 10, 0, 0, 1, 10, 0, 0, 2, 4, 210, 22, 46, 6}
+
+func TestCollectorToIntermediate(t *testing.T) {
+	registry.LoadRegistry()
+	messageChan := make(chan *entities.Message)
+	address, err := net.ResolveUDPAddr("udp", "0.0.0.0:4739")
+	if err != nil {
+		t.Error(err)
+	}
+	// Initialize aggregation process and collecting process
+	ap, _ := intermediate.InitAggregationProcess(messageChan, 2)
+	cp, _ := collector.InitCollectingProcess(address, 1024, 0, messageChan)
+
+	go func() {
+		time.Sleep(time.Second)
+		conn, err := net.DialUDP("udp", nil, address)
+		if err != nil {
+			t.Errorf("UDP Collecting Process does not start correctly.")
+		}
+		defer conn.Close()
+		conn.Write(templatePacket)
+		time.Sleep(time.Second)
+		conn.Write(dataPacket)
+	}()
+	go func() {
+		ap.Start()
+	}()
+	go func() {
+		time.Sleep(4 * time.Second)
+		cp.Stop()
+		ap.Stop()
+	}()
+	cp.Start()
+	assert.Equal(t, 1, len(ap.GetTupleRecordMap()), "Aggregation process should store the data record to map with corresponding tuple.")
+	tuple := intermediate.Tuple{SourceAddress: 167772161, DestinationAddress: 167772162, Protocol: 6, SourcePort: 1234, DestinationPort: 5678}
+	assert.NotNil(t, ap.GetTupleRecordMap()[tuple])
+	record := ap.GetTupleRecordMap()[tuple]
+	elements := record[0].GetInfoElements()
+	assert.Equal(t, 7, len(elements), "There should be two more fields for exporter information in the record.")
+	assert.Equal(t, uint32(1), elements[6].Value, "originalObservationDomainId should be added correctly in record.")
+}

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -66,9 +66,8 @@ func testExporterToCollector(address net.Addr, isMultipleRecord bool, t *testing
 	// Load the global registry
 	registry.LoadRegistry()
 	// Initialize collecting process
-	messageChan := make(chan *entities.Message)
 	messages := make([]*entities.Message, 0)
-	cp, _ := collector.InitCollectingProcess(address, 1024, 0, messageChan)
+	cp, _ := collector.InitCollectingProcess(address, 1024, 0, true)
 
 	go func() { // Start exporting process in go routine
 		time.Sleep(2 * time.Second) // wait for collector to be ready
@@ -213,7 +212,7 @@ func testExporterToCollector(address net.Addr, isMultipleRecord bool, t *testing
 		cp.Stop() // Close collecting process
 	}()
 	go func() {
-		for message := range messageChan {
+		for message := range cp.GetMsgChan() {
 			messages = append(messages, message)
 		}
 	}()

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -67,7 +67,7 @@ func testExporterToCollector(address net.Addr, isMultipleRecord bool, t *testing
 	registry.LoadRegistry()
 	// Initialize collecting process
 	messages := make([]*entities.Message, 0)
-	cp, _ := collector.InitCollectingProcess(address, 1024, 0, true)
+	cp, _ := collector.InitCollectingProcess(address, 1024, 0)
 
 	go func() { // Start exporting process in go routine
 		time.Sleep(2 * time.Second) // wait for collector to be ready
@@ -228,7 +228,7 @@ func testExporterToCollector(address net.Addr, isMultipleRecord bool, t *testing
 	if !ok {
 		t.Error("Template packet is not decoded correctly.")
 	}
-	templateElements := templateSet.GetRecords()[0].GetInfoElements()
+	templateElements := templateSet.GetRecords()[0].GetOrderedElementList()
 	assert.Equal(t, uint32(0), templateElements[0].Element.EnterpriseId, "Template record is not stored correctly.")
 	assert.Equal(t, "sourceIPv4Address", templateElements[0].Element.Name, "Template record is not stored correctly.")
 	assert.Equal(t, "destinationIPv4Address", templateElements[1].Element.Name, "Template record is not stored correctly.")
@@ -240,13 +240,13 @@ func testExporterToCollector(address net.Addr, isMultipleRecord bool, t *testing
 		t.Error("Data packet is not decoded correctly.")
 	}
 
-	dataElements := dataSet.GetRecords()[0].GetInfoElements()
+	dataElements := dataSet.GetRecords()[0].GetOrderedElementList()
 	assert.Equal(t, net.IP([]byte{1, 2, 3, 4}), dataElements[0].Value, "DataSet does not store elements (IANA) correctly.")
 	assert.Equal(t, uint64(12345678), dataElements[2].Value, "DataSet does not store reverse information elements (IANA) correctly.")
 	assert.Equal(t, "pod1", dataElements[3].Value, "DataSet does not store elements (Antrea) correctly.")
 	assert.Equal(t, uint32(1257894000), dataElements[4].Value, "DataSet does not store elements (IANA) correctly.")
 	if isMultipleRecord {
-		dataElements := dataSet.GetRecords()[1].GetInfoElements()
+		dataElements := dataSet.GetRecords()[1].GetOrderedElementList()
 		assert.Equal(t, net.IP([]byte{4, 3, 2, 1}), dataElements[0].Value, "DataSet does not store multiple records correctly.")
 		assert.Equal(t, uint64(0), dataElements[2].Value, "DataSet does not store multiple records correctly.")
 		assert.Equal(t, "pod2", dataElements[3].Value, "DataSet does not store multiple records correctly.")


### PR DESCRIPTION
Fixes #3 

This PR is based on PR #49 refactor of set and record struct (will need rebase after #49 merged). Changes made:
1. Modify message list in collector to channel as buffer to support multi producers -> multiple consumers
2. Support adding exporter related info `originalObservationDomainId` and `originalExporterIPv4Address` in collecting process
3. Add aggregation related methods to aggregate messages by 5-tuple and correlate records to fill fields.
4. Support multiple workers to process message.
5. Add unit tests and integration test from collector to intermediate process.