### PR TITLE
Add codecov token and flags for tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,9 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
-        file: ./coverage_unit.txt
+        file: .coverage/coverage_unit.txt
+        flags: unit-tests
+        name: codecov-unit-test
 
   test-integration:
     name: Integration test
@@ -51,7 +53,9 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
-        file: ./coverage_integration.txt
+        file: .coverage/coverage_integration.txt
+        flags: integration-tests
+        name: codecov-integration-test
 
   codegen:
     name: Check code generation

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pkg/registry/build_registry/build_registry
+.coverage/
 
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,14 @@ codegen:
 	GO111MODULE=on $(GO) get github.com/golang/mock/mockgen@v1.4.3
 	PATH=$$PATH:$(GOPATH)/bin $(GO) generate ./...
 
-test-unit:
-	$(GO) test ./... -covermode=atomic -coverprofile=coverage_unit.txt
+.coverage:
+	mkdir -p ./.coverage
 
-test-integration:
-	$(GO) test ./pkg/test/... -tags=integration -covermode=atomic -coverprofile=coverage_integration.txt -coverpkg github.com/vmware/go-ipfix/pkg/collector,github.com/vmware/go-ipfix/pkg/exporter
+test-unit: .coverage
+	$(GO) test ./... -covermode=atomic -coverprofile=.coverage/coverage_unit.txt
+
+test-integration: .coverage
+	$(GO) test ./pkg/test/... -tags=integration -covermode=atomic -coverprofile=.coverage/coverage_integration.txt -coverpkg github.com/vmware/go-ipfix/pkg/collector,github.com/vmware/go-ipfix/pkg/exporter
 
 golangci:
 	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.21.0


### PR DESCRIPTION
Secrets environment variable seems not working for Codecov. Directly added token to yaml file as Antrea did.
Also, to better distinguish unit and integration test coverage in the report, I added the flags to workflow steps and arranged the coverage reports into one folder.