### PR TITLE
Change reverse information element naming

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -16,6 +16,8 @@ package registry
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/vmware/go-ipfix/pkg/entities"
 )
 
@@ -102,7 +104,8 @@ func getIANAReverseInfoElement(name string) (*entities.InfoElement, error) {
 		err := fmt.Errorf("IANA Registry: The information element %s is not reverse element", name)
 		return ie, err
 	}
-	return entities.NewInfoElement(name, ie.ElementId, ie.DataType, IANAReversedEnterpriseID, ie.Len), nil
+	reverseName := "reverse" + strings.Title(ie.Name)
+	return entities.NewInfoElement(reverseName, ie.ElementId, ie.DataType, IANAReversedEnterpriseID, ie.Len), nil
 }
 
 // Non-reversible Information Elements follow Section 6.1 of RFC5103

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -56,7 +56,7 @@ func TestGetIANAReverseIE(t *testing.T) {
 	assert.NotEqual(t, nil, error, "GetIANAReverseIE should return error when ie is not reversible.")
 	// reverse InfoElement exists
 	reverseIE, error = getIANAReverseInfoElement("deltaFlowCount")
-	assert.Equal(t, "deltaFlowCount", reverseIE.Name, "GetIANAReverseIE does not return correct reverse ie.")
+	assert.Equal(t, "reverseDeltaFlowCount", reverseIE.Name, "GetIANAReverseIE does not return correct reverse ie.")
 	assert.Equal(t, IANAReversedEnterpriseID, reverseIE.EnterpriseId, "GetIANAReverseIE does not return correct reverse ie.")
 }
 
@@ -67,7 +67,7 @@ func TestGetInfoElementFromID(t *testing.T) {
 	assert.NotEqual(t, nil, err, "TestGetInfoElementFromID should return error when ie does not exist.")
 	// InfoElement exists (reverse InfoElement)
 	ie, err = GetInfoElementFromID(1, IANAReversedEnterpriseID)
-	assert.Equal(t, "octetDeltaCount", ie.Name, "TestGetInfoElementFromID does not return correct reverse ie.")
+	assert.Equal(t, "reverseOctetDeltaCount", ie.Name, "TestGetInfoElementFromID does not return correct reverse ie.")
 	assert.Equal(t, IANAReversedEnterpriseID, ie.EnterpriseId, "TestGetInfoElementFromID does not return correct reverse ie.")
 	// InfoElement exists (IANA InfoElement)
 	ie, err = GetInfoElementFromID(1, IANAEnterpriseID)

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -73,7 +73,7 @@ func testExporterToCollector(address net.Addr, t *testing.T) {
 		}
 		tempRec.AddInfoElement(element, nil)
 
-		element, err = registry.GetInfoElement("octetDeltaCount", registry.IANAReversedEnterpriseID)
+		element, err = registry.GetInfoElement("reverseOctetDeltaCount", registry.IANAReversedEnterpriseID)
 		if err != nil {
 			klog.Errorf("Did not find the reverse element of octetDeltaCount")
 		}
@@ -111,7 +111,7 @@ func testExporterToCollector(address net.Addr, t *testing.T) {
 		}
 		dataRec.AddInfoElement(element, net.ParseIP("5.6.7.8"))
 
-		element, err = registry.GetInfoElement("octetDeltaCount", registry.IANAReversedEnterpriseID)
+		element, err = registry.GetInfoElement("reverseOctetDeltaCount", registry.IANAReversedEnterpriseID)
 		if err != nil {
 			klog.Errorf("Did not find the reverse element of octetDeltaCount")
 		}


### PR DESCRIPTION
Change reverse ie naming back to the one with `reverse` prefix.
Reason:
Elastic stack collector in Antrea will take reverse ie and ie with the same name (but different enterprise ID) as duplicates can cannot decode the message correctly. 
Use prefix `reverse` but not `reverse_` is also to keep consistent with elastic definition.