### PR TITLE
Add upload release assets github workflow

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -1,0 +1,31 @@
+name: Upload assets to release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Build collector binary for Linux amd64
+        run: |
+          make collector
+      - name: Upload collector binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/collector
+          asset_name: ipfix-collector-linux-x86_64
+          asset_content_type: application/octet-stream

--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -1,3 +1,17 @@
+// Copyright 2020 VMware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (


### PR DESCRIPTION
Asset is collector binary.

Added the missing license header in new file collector.go.