### PR TITLE
Add docker image for ipfix-collector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build and push the latest image if needed
+
+on:
+  pull_request:
+    branches:
+      - master
+      - release-*
+  push:
+    branches:
+      - master
+      - release-*
+
+jobs:
+  build:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: [ubuntu-18.04]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build ipfix-collector Docker image
+        run: make docker-collector
+      - name: Push ipfix-collector Docker image to Antrea Docker registry
+        if: ${{ github.repository == 'vmware/go-ipfix' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push antrea/ipfix-collector:latest

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -1,0 +1,22 @@
+name: Build and push a release image
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: [ubuntu-18.04]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build go-ipfix Docker images and push to Antrea Docker registry
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          TAG: ${{ github.ref }}
+        run: |
+          make docker-collector
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker tag antrea/ipfix-collector antrea/ipfix-collector:"${TAG:10}"
+          docker push antrea/ipfix-collector:"${TAG:10}"

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,9 @@ golangci:
 collector:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) github.com/vmware/go-ipfix/cmd/collector/
+
+### Docker images ###
+
+docker-collector:
+	@echo "===> Building antrea/ipfix-collector Docker image <==="
+	docker build --pull -t antrea/ipfix-collector -f build/images/Dockerfile.build.collector .

--- a/build/images/Dockerfile.build.collector
+++ b/build/images/Dockerfile.build.collector
@@ -1,0 +1,19 @@
+FROM golang:1.15 as go-ipfix-build
+
+WORKDIR /go-ipfix
+
+COPY go.mod /go-ipfix/go.mod
+
+RUN go mod download
+
+COPY . /go-ipfix
+
+RUN make collector
+
+FROM ubuntu:18.04
+
+LABEL maintainer="go-ipfix"
+LABEL description="A Docker image based on Ubuntu 18.04 which contains a IPFIX collector"
+
+COPY --from=go-ipfix-build /go-ipfix/bin/collector /usr/local/bin/
+ENTRYPOINT "collector"


### PR DESCRIPTION
Also add github workflow to push to Antrea org of docker registry.
Image is pushed as antrea/ipfix-collector with latest (for master branch) or release tag (for releases).