### PR TITLE
Fix unit tests with -race for collector and intermediate process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ codegen:
 	mkdir -p ./.coverage
 
 test-unit: .coverage
-	$(GO) test ./... -covermode=atomic -coverprofile=.coverage/coverage_unit.txt
+	$(GO) test -race ./... -covermode=atomic -coverprofile=.coverage/coverage_unit.txt
 
 test-integration: .coverage
-	$(GO) test ./pkg/test/... -tags=integration -covermode=atomic -coverprofile=.coverage/coverage_integration.txt -coverpkg github.com/vmware/go-ipfix/pkg/collector,github.com/vmware/go-ipfix/pkg/exporter,github.com/vmware/go-ipfix/pkg/intermediate
+	$(GO) test -race ./pkg/test/... -tags=integration -covermode=atomic -coverprofile=.coverage/coverage_integration.txt -coverpkg github.com/vmware/go-ipfix/pkg/collector,github.com/vmware/go-ipfix/pkg/exporter,github.com/vmware/go-ipfix/pkg/intermediate
 
 golangci:
 	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
+	k8s.io/apimachinery v0.18.4
 	k8s.io/component-base v0.18.4
 	k8s.io/klog v1.0.0
 )

--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -33,8 +33,8 @@ import (
 type CollectingProcess struct {
 	// for each obsDomainID, there is a map of templates
 	templatesMap map[uint32]map[uint16][]*entities.InfoElement
-	// templatesLock allows multiple readers or one writer at the same time
-	templatesLock sync.RWMutex
+	// mutex allows multiple readers or one writer at the same time
+	mutex sync.RWMutex
 	// template lifetime
 	templateTTL uint32
 	// server information
@@ -47,8 +47,6 @@ type CollectingProcess struct {
 	messageChan chan *entities.Message
 	// maps each client to its client handler (required channels)
 	clients map[string]*clientHandler
-	// clientsLock allows multiple readers or one writer to access clients map at the same time
-	clientsLock sync.RWMutex
 }
 
 type clientHandler struct {
@@ -59,7 +57,7 @@ type clientHandler struct {
 func InitCollectingProcess(address net.Addr, maxBufferSize uint16, templateTTL uint32) (*CollectingProcess, error) {
 	collectProc := &CollectingProcess{
 		templatesMap:  make(map[uint32]map[uint16][]*entities.InfoElement),
-		templatesLock: sync.RWMutex{},
+		mutex:         sync.RWMutex{},
 		templateTTL:   templateTTL,
 		address:       address,
 		maxBufferSize: maxBufferSize,
@@ -80,13 +78,16 @@ func (cp *CollectingProcess) Start() {
 
 func (cp *CollectingProcess) Stop() {
 	cp.stopChan <- true
-	if cp.messageChan != nil {
-		close(cp.messageChan)
-	}
 }
 
 func (cp *CollectingProcess) GetMsgChan() chan *entities.Message {
 	return cp.messageChan
+}
+
+func (cp *CollectingProcess) CloseMsgChan() {
+	cp.mutex.Lock()
+	defer cp.mutex.Unlock()
+	close(cp.messageChan)
 }
 
 func (cp *CollectingProcess) createClient() *clientHandler {
@@ -97,21 +98,29 @@ func (cp *CollectingProcess) createClient() *clientHandler {
 }
 
 func (cp *CollectingProcess) addClient(address string, client *clientHandler) {
-	cp.clientsLock.Lock()
-	defer cp.clientsLock.Unlock()
+	cp.mutex.Lock()
+	defer cp.mutex.Unlock()
 	cp.clients[address] = client
 }
 
 func (cp *CollectingProcess) deleteClient(name string) {
-	cp.clientsLock.Lock()
-	defer cp.clientsLock.Unlock()
+	cp.mutex.Lock()
+	defer cp.mutex.Unlock()
 	delete(cp.clients, name)
 }
 
 func (cp *CollectingProcess) getClientCount() int {
-	cp.clientsLock.RLock()
-	defer cp.clientsLock.RUnlock()
+	cp.mutex.RLock()
+	defer cp.mutex.RUnlock()
 	return len(cp.clients)
+}
+
+func (cp *CollectingProcess) closeAllClients() {
+	cp.mutex.Lock()
+	defer cp.mutex.Unlock()
+	for _, client := range cp.clients {
+		client.errChan <- true
+	}
 }
 
 func (cp *CollectingProcess) decodePacket(packetBuffer *bytes.Buffer, exportAddress string) (*entities.Message, error) {
@@ -243,7 +252,8 @@ func (cp *CollectingProcess) decodeDataSet(dataBuffer *bytes.Buffer, obsDomainID
 }
 
 func (cp *CollectingProcess) addTemplate(obsDomainID uint32, templateID uint16, elementsWithValue []*entities.InfoElementWithValue) {
-	cp.templatesLock.Lock()
+	cp.mutex.Lock()
+	defer cp.mutex.Unlock()
 	if _, exists := cp.templatesMap[obsDomainID]; !exists {
 		cp.templatesMap[obsDomainID] = make(map[uint16][]*entities.InfoElement)
 	}
@@ -252,7 +262,6 @@ func (cp *CollectingProcess) addTemplate(obsDomainID uint32, templateID uint16, 
 		elements = append(elements, elementWithValue.Element)
 	}
 	cp.templatesMap[obsDomainID][templateID] = elements
-	cp.templatesLock.Unlock()
 	// template lifetime management
 	if cp.address.Network() == "tcp" {
 		return
@@ -275,8 +284,8 @@ func (cp *CollectingProcess) addTemplate(obsDomainID uint32, templateID uint16, 
 }
 
 func (cp *CollectingProcess) getTemplate(obsDomainID uint32, templateID uint16) ([]*entities.InfoElement, error) {
-	cp.templatesLock.RLock()
-	defer cp.templatesLock.RUnlock()
+	cp.mutex.RLock()
+	defer cp.mutex.RUnlock()
 	if elements, exists := cp.templatesMap[obsDomainID][templateID]; exists {
 		return elements, nil
 	} else {
@@ -285,8 +294,8 @@ func (cp *CollectingProcess) getTemplate(obsDomainID uint32, templateID uint16) 
 }
 
 func (cp *CollectingProcess) deleteTemplate(obsDomainID uint32, templateID uint16) {
-	cp.templatesLock.Lock()
-	defer cp.templatesLock.Unlock()
+	cp.mutex.Lock()
+	defer cp.mutex.Unlock()
 	delete(cp.templatesMap[obsDomainID], templateID)
 }
 

--- a/pkg/collector/tcp.go
+++ b/pkg/collector/tcp.go
@@ -30,14 +30,10 @@ func (cp *CollectingProcess) startTCPServer() {
 			go cp.handleTCPClient(conn, &wg)
 		}
 	}()
-	if <-cp.stopChan {
-		// close all connections
-		for _, client := range cp.clients {
-			client.errChan <- true
-		}
-		wg.Wait()
-		return
-	}
+	<-cp.stopChan
+	// close all connections
+	cp.closeAllClients()
+	wg.Wait()
 }
 
 func (cp *CollectingProcess) handleTCPClient(conn net.Conn, wg *sync.WaitGroup) {
@@ -78,8 +74,6 @@ func (cp *CollectingProcess) handleTCPClient(conn net.Conn, wg *sync.WaitGroup) 
 			}
 		}
 	}()
-	if <-client.errChan {
-		cp.deleteClient(address)
-		return
-	}
+	<-client.errChan
+	cp.deleteClient(address)
 }

--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -263,7 +263,7 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got error when resolving UDP address: %v", err)
 	}
-	conn, err := net.ListenUDP("udp", udpAddr)
+	conn, _ := net.ListenUDP("udp", udpAddr)
 	t.Log("Created local server on random available port for testing")
 
 	buffCh := make(chan []byte)

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -1,16 +1,33 @@
+// Copyright 2020 VMware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration
+
 package test
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/vmware/go-ipfix/pkg/collector"
 	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/intermediate"
 	"github.com/vmware/go-ipfix/pkg/registry"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var templatePacket = []byte{0, 10, 0, 76, 95, 154, 84, 121, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 60, 1, 0, 0, 9, 0, 8, 0, 4, 0, 12, 0, 4, 0, 7, 0, 2, 0, 11, 0, 2, 0, 4, 0, 1, 128, 101, 255, 255, 0, 0, 220, 186, 128, 103, 255, 255, 0, 0, 220, 186, 128, 106, 0, 4, 0, 0, 220, 186, 128, 107, 0, 2, 0, 0, 220, 186}
@@ -32,30 +49,23 @@ func TestCollectorToIntermediate(t *testing.T) {
 	// Initialize aggregation process and collecting process
 	cp, _ := collector.InitCollectingProcess(address, 1024, 0)
 	ap, _ := intermediate.InitAggregationProcess(cp.GetMsgChan(), 2, fields)
-
+	go cp.Start()
+	waitForCollectorReady(t, address)
 	go func() {
-		time.Sleep(time.Second)
 		conn, err := net.DialUDP("udp", nil, address)
 		if err != nil {
 			t.Errorf("UDP Collecting Process does not start correctly.")
 		}
 		defer conn.Close()
 		conn.Write(templatePacket)
-		time.Sleep(time.Second)
 		conn.Write(dataPacket1)
-		time.Sleep(time.Second)
 		conn.Write(dataPacket2)
 	}()
-	go func() {
-		ap.Start()
-	}()
-	go func() {
-		time.Sleep(4 * time.Second)
-		cp.Stop()
-		ap.Stop()
-	}()
-	cp.Start()
-	ap.ForAllRecordsDo(copyFlowKeyRecordMap)
+	go ap.Start()
+	waitForAggrationFinished(t, ap)
+	cp.Stop()
+	ap.Stop()
+
 	assert.Equal(t, 1, len(flowKeyRecordMap), "Aggregation process should store the data record to map with corresponding flow key.")
 	flowKey := intermediate.FlowKey{SourceAddress: "1.2.3.4", DestinationAddress: "5.6.7.8", Protocol: 6, SourcePort: 1234, DestinationPort: 5678}
 	assert.NotNil(t, flowKeyRecordMap[flowKey])
@@ -73,4 +83,30 @@ func TestCollectorToIntermediate(t *testing.T) {
 func copyFlowKeyRecordMap(key intermediate.FlowKey, records []entities.Record) error {
 	flowKeyRecordMap[key] = records
 	return nil
+}
+
+func waitForCollectorReady(t *testing.T, address net.Addr) {
+	checkConn := func() (bool, error) {
+		if _, err := net.Dial(address.Network(), address.String()); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if err := wait.Poll(100 * time.Millisecond, 500 * time.Millisecond, checkConn); err != nil {
+		t.Errorf("Cannot establish connection to %s", address.String())
+	}
+}
+
+func waitForAggrationFinished(t *testing.T, ap *intermediate.AggregationProcess) {
+	checkConn := func() (bool, error) {
+		ap.ForAllRecordsDo(copyFlowKeyRecordMap)
+		if len(flowKeyRecordMap) > 0 {
+			return true, nil
+		} else {
+			return false, fmt.Errorf("aggregation process does not process and store data correctly")
+		}
+	}
+	if err := wait.Poll(100 * time.Millisecond, 500 * time.Millisecond, checkConn); err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
Cherry-picked unit tests fixes for exporter from #91 
Fixed with collector and intermediate process and added `-race` in unit tests to check for race conditions.
partially fixes #90 