### PR TITLE
Expose fields in AggregateElements and add integration tests

### DIFF
--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -403,7 +403,8 @@ func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {
 		defer conn.Close()
 		conn.Write(validTemplatePacket)
 		time.Sleep(time.Millisecond)
-		assert.Equal(t, 2, cp.getClientCount(), "There should be two tcp clients.")
+		// function waitForCollectorReady may introduce more clients when testing connection
+		assert.GreaterOrEqual(t, 2, cp.getClientCount(), "There should be at least two tcp clients.")
 	}()
 	// there should be two messages received
 	<-cp.GetMsgChan()

--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -263,7 +263,7 @@ func (a *AggregationProcess) aggregateRecords(incomingRecord, existingRecord ent
 		return nil
 	}
 
-	for _, element := range a.aggregateElements.nonStatsElements {
+	for _, element := range a.aggregateElements.NonStatsElements {
 		if ieWithValue, exist := incomingRecord.GetInfoElementWithValue(element); exist {
 			switch ieWithValue.Element.Name {
 			case "flowEndSeconds":
@@ -280,9 +280,9 @@ func (a *AggregationProcess) aggregateRecords(incomingRecord, existingRecord ent
 		}
 	}
 
-	statsElementList := a.aggregateElements.statsElements
-	antreaSourceStatsElements := a.aggregateElements.aggregatedSourceStatsElements
-	antreaDestinationStatsElements := a.aggregateElements.aggregatedDestinationStatsElements
+	statsElementList := a.aggregateElements.StatsElements
+	antreaSourceStatsElements := a.aggregateElements.AggregatedSourceStatsElements
+	antreaDestinationStatsElements := a.aggregateElements.AggregatedDestinationStatsElements
 	for i, element := range statsElementList {
 		isDelta := false
 		if strings.Contains(element, "Delta") {
@@ -331,9 +331,9 @@ func (a *AggregationProcess) addFieldsForStatsAggregation(record entities.Record
 	if a.aggregateElements == nil {
 		return nil
 	}
-	statsElementList := a.aggregateElements.statsElements
-	antreaSourceStatsElements := a.aggregateElements.aggregatedSourceStatsElements
-	antreaDestinationStatsElements := a.aggregateElements.aggregatedDestinationStatsElements
+	statsElementList := a.aggregateElements.StatsElements
+	antreaSourceStatsElements := a.aggregateElements.AggregatedSourceStatsElements
+	antreaDestinationStatsElements := a.aggregateElements.AggregatedDestinationStatsElements
 	antreaElements := append(antreaSourceStatsElements, antreaDestinationStatsElements...)
 
 	for _, element := range antreaElements {

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -471,10 +471,10 @@ func TestCorrelateRecordsForIntraNodeFlow(t *testing.T) {
 func TestAggregateRecordsForInterNodeFlow(t *testing.T) {
 	messageChan := make(chan *entities.Message)
 	aggElements := &AggregationElements{
-		nonStatsElements:                   nonStatsElementList,
-		statsElements:                      statsElementList,
-		aggregatedSourceStatsElements:      antreaSourceStatsElementList,
-		aggregatedDestinationStatsElements: antreaDestinationStatsElementList,
+		NonStatsElements:                   nonStatsElementList,
+		StatsElements:                      statsElementList,
+		AggregatedSourceStatsElements:      antreaSourceStatsElementList,
+		AggregatedDestinationStatsElements: antreaDestinationStatsElementList,
 	}
 	input := AggregationInput{
 		MessageChan:       messageChan,

--- a/pkg/intermediate/types.go
+++ b/pkg/intermediate/types.go
@@ -37,10 +37,10 @@ type AggregationFlowRecord struct {
 }
 
 type AggregationElements struct {
-	nonStatsElements                   []string
-	statsElements                      []string
-	aggregatedSourceStatsElements      []string
-	aggregatedDestinationStatsElements []string
+	NonStatsElements                   []string
+	StatsElements                      []string
+	AggregatedSourceStatsElements      []string
+	AggregatedDestinationStatsElements []string
 }
 
 type FlowKeyRecordMapCallBack func(key FlowKey, record AggregationFlowRecord) error


### PR DESCRIPTION
Users cannot create AggregateElements in AggregationInput because elements are not exposed as public. 
Added integration tests to ensure everything work well.
Also refactored test cases in exporter-collector tests.