### PR TITLE
Provide delete function in intermediate process without lock

### DIFF
--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -136,9 +136,18 @@ func (a *AggregationProcess) ForAllRecordsDo(callback FlowKeyRecordMapCallBack) 
 	return nil
 }
 
-func (a *AggregationProcess) DeleteFlowKeyFromMap(flowKey FlowKey) {
+func (a *AggregationProcess) DeleteFlowKeyFromMapWithLock(flowKey FlowKey) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
+	delete(a.flowKeyRecordMap, flowKey)
+}
+
+// DeleteFlowKeyFromMapWithoutLock need to be used only when the caller has already
+// acquired the lock. For example, this can be used in a callback of ForAllRecordsDo
+// function.
+// TODO:Remove this when there is notion of invalid flows supported in aggregation
+// process.
+func (a *AggregationProcess) DeleteFlowKeyFromMapWithoutLock(flowKey FlowKey) {
 	delete(a.flowKeyRecordMap, flowKey)
 }
 

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -428,13 +428,13 @@ func TestCorrelateRecordsForInterNodeFlow(t *testing.T) {
 	runCorrelationAndCheckResult(t, ap, record1, record2, false, false)
 	// Cleanup the flowKeyMap in aggregation process.
 	flowKey1, _ := getFlowKeyFromRecord(record1)
-	ap.DeleteFlowKeyFromMap(*flowKey1)
+	ap.DeleteFlowKeyFromMapWithLock(*flowKey1)
 	// Test the scenario, where record2 is added first and then record1.
 	record1 = createDataMsgForSrc(t, false, false, false).GetSet().GetRecords()[0]
 	record2 = createDataMsgForDst(t, false, false, false).GetSet().GetRecords()[0]
 	runCorrelationAndCheckResult(t, ap, record2, record1, false, false)
 	// Cleanup the flowKeyMap in aggregation process.
-	ap.DeleteFlowKeyFromMap(*flowKey1)
+	ap.DeleteFlowKeyFromMapWithLock(*flowKey1)
 
 	// Test IPv6 fields.
 	// Test the scenario, where record1 is added first and then record2.
@@ -442,7 +442,7 @@ func TestCorrelateRecordsForInterNodeFlow(t *testing.T) {
 	record2 = createDataMsgForDst(t, true, false, false).GetSet().GetRecords()[0]
 	runCorrelationAndCheckResult(t, ap, record1, record2, true, false)
 	// Cleanup the flowKeyMap in aggregation process.
-	ap.DeleteFlowKeyFromMap(*flowKey1)
+	ap.DeleteFlowKeyFromMapWithLock(*flowKey1)
 	// Test the scenario, where record2 is added first and then record1.
 	record1 = createDataMsgForSrc(t, true, false, false).GetSet().GetRecords()[0]
 	record2 = createDataMsgForDst(t, true, false, false).GetSet().GetRecords()[0]
@@ -462,7 +462,7 @@ func TestCorrelateRecordsForIntraNodeFlow(t *testing.T) {
 	runCorrelationAndCheckResult(t, ap, record1, nil, false, true)
 	// Cleanup the flowKeyMap in aggregation process.
 	flowKey1, _ := getFlowKeyFromRecord(record1)
-	ap.DeleteFlowKeyFromMap(*flowKey1)
+	ap.DeleteFlowKeyFromMapWithLock(*flowKey1)
 	// Test IPv6 fields.
 	record1 = createDataMsgForSrc(t, true, true, false).GetSet().GetRecords()[0]
 	runCorrelationAndCheckResult(t, ap, record1, nil, true, true)
@@ -492,7 +492,7 @@ func TestAggregateRecordsForInterNodeFlow(t *testing.T) {
 	runAggregationAndCheckResult(t, ap, srcRecord, dstRecord, latestSrcRecord, latestDstRecord, false)
 }
 
-func TestDeleteTupleFromMap(t *testing.T) {
+func TestDeleteFlowKeyFromMapWithLock(t *testing.T) {
 	messageChan := make(chan *entities.Message)
 	input := AggregationInput{
 		MessageChan:     messageChan,
@@ -510,9 +510,37 @@ func TestDeleteTupleFromMap(t *testing.T) {
 	}
 	aggregationProcess.flowKeyRecordMap[flowKey1] = aggFlowRecord
 	assert.Equal(t, 1, len(aggregationProcess.flowKeyRecordMap))
-	aggregationProcess.DeleteFlowKeyFromMap(flowKey2)
+	aggregationProcess.DeleteFlowKeyFromMapWithLock(flowKey2)
 	assert.Equal(t, 1, len(aggregationProcess.flowKeyRecordMap))
-	aggregationProcess.DeleteFlowKeyFromMap(flowKey1)
+	aggregationProcess.DeleteFlowKeyFromMapWithLock(flowKey1)
+	assert.Empty(t, aggregationProcess.flowKeyRecordMap)
+}
+
+func TestDeleteFlowKeyFromMapWithoutLock(t *testing.T) {
+	messageChan := make(chan *entities.Message)
+	input := AggregationInput{
+		MessageChan:     messageChan,
+		WorkerNum:       2,
+		CorrelateFields: fields,
+	}
+	aggregationProcess, _ := InitAggregationProcess(input)
+	message := createDataMsgForSrc(t, false, false, false)
+	flowKey1 := FlowKey{"10.0.0.1", "10.0.0.2", 6, 1234, 5678}
+	flowKey2 := FlowKey{"2001:0:3238:dfe1:63::fefb", "2001:0:3238:dfe1:63::fefc", 6, 1234, 5678}
+	aggFlowRecord := AggregationFlowRecord{
+		message.GetSet().GetRecords()[0],
+		true,
+		true,
+	}
+	aggregationProcess.flowKeyRecordMap[flowKey1] = aggFlowRecord
+	assert.Equal(t, 1, len(aggregationProcess.flowKeyRecordMap))
+	aggregationProcess.mutex.Lock()
+	aggregationProcess.DeleteFlowKeyFromMapWithoutLock(flowKey2)
+	aggregationProcess.mutex.Unlock()
+	assert.Equal(t, 1, len(aggregationProcess.flowKeyRecordMap))
+	aggregationProcess.mutex.Lock()
+	aggregationProcess.DeleteFlowKeyFromMapWithoutLock(flowKey1)
+	aggregationProcess.mutex.Unlock()
 	assert.Empty(t, aggregationProcess.flowKeyRecordMap)
 }
 


### PR DESCRIPTION
The current delete function acquires lock. In some cases, caller will already
have acquired the lock on flowKeyRecordMap in aggregation process. In those
cases, we will need another function that do not acquire lock.

Cherry-picking the commit from release-0.3.0 (v0.3.2) to release-0.4.0