### PR TITLE
Expose pathMTU in exporter

### DIFF
--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -175,6 +175,14 @@ func (ep *ExportingProcess) SendSet(set entities.Set) (int, error) {
 	return bytesSent, nil
 }
 
+func (ep *ExportingProcess) GetMsgSizeLimit() int {
+	if ep.connToCollector.LocalAddr().Network() == "tcp" {
+		return entities.MaxTcpSocketMsgSize
+	} else {
+		return ep.pathMTU
+	}
+}
+
 func (ep *ExportingProcess) CloseConnToCollector() {
 	if !isChanClosed(ep.templateRefCh) {
 		close(ep.templateRefCh) // Close template refresh channel


### PR DESCRIPTION
so that users can use it to test whether current message size exceeds limit or not