### PR TITLE
Fix slicing problem on tcp collector

### DIFF
--- a/pkg/collector/tcp.go
+++ b/pkg/collector/tcp.go
@@ -83,6 +83,10 @@ func (cp *CollectingProcess) handleTCPClient(conn net.Conn, wg *sync.WaitGroup) 
 					klog.Error(err)
 					break out
 				}
+				if size < length {
+					klog.Errorf("Message length %v is larger than size read from buffer %v", length, size)
+					break out
+				}
 				size = size - length
 				// get the message here
 				message, err := cp.decodePacket(bytes.NewBuffer(buff[0:length]), address)


### PR DESCRIPTION
fixes #124 
For invalid messages, `getMessageLength` may return an invalid value of length which is larger than the slice size. This PR fixes by checking whether the length is valid.