### PR TITLE
Modify the input of Exporting and Collecting process

### DIFF
--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"net"
 	"os"
 	"os/signal"
 	"strconv"
@@ -106,28 +105,12 @@ func signalHandler(stopCh chan struct{}, messageReceived chan *entities.Message)
 
 func run() error {
 	klog.Info("Starting IPFIX collector")
-
 	// Load the IPFIX global registry
 	registry.LoadRegistry()
-
-	var netAddr net.Addr
-	var err error
-	if IPFIXTransport == "tcp" {
-		netAddr, err = net.ResolveTCPAddr("tcp", IPFIXAddr+":"+strconv.Itoa(int(IPFIXPort)))
-		if err != nil {
-			return err
-		}
-	} else if IPFIXTransport == "udp" {
-		netAddr, err = net.ResolveUDPAddr("udp", IPFIXAddr+":"+strconv.Itoa(int(IPFIXPort)))
-		if err != nil {
-			return err
-		}
-	} else {
-		return fmt.Errorf("input given ipfix.transport flag is not supported or valid")
-	}
 	// Initialize collecting process
 	cpInput := collector.CollectorInput{
-		Address:       netAddr,
+		Address:       IPFIXAddr + ":" + strconv.Itoa(int(IPFIXPort)),
+		Protocol:      IPFIXTransport,
 		MaxBufferSize: 65535,
 		TemplateTTL:   0,
 		IsEncrypted:   false,

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,7 @@ golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -165,6 +165,9 @@ PQQDAgNIADBFAiEAzUT2hG3WChJh8cBo7EMQan2eJiF96OlSB+rWKKMaoGACIGOp
 RVaPKj9ad0Z/3GiwaxtW+74bvc2vF3JS9cRU6DhY
 -----END CERTIFICATE-----
 `
+	tcpTransport = "tcp"
+	udpTransport = "udp"
+	hostPort     = "127.0.0.1:0"
 )
 
 var elementsWithValue = []*entities.InfoElementWithValue{
@@ -178,12 +181,9 @@ func init() {
 }
 
 func TestTCPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
-	address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      tcpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   false,
@@ -213,12 +213,9 @@ func TestTCPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 }
 
 func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
-	address, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      udpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   false,
@@ -238,7 +235,7 @@ func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 		if err != nil {
 			t.Errorf("UDP Address cannot be resolved.")
 		}
-		conn, err := net.DialUDP("udp", nil, resolveAddr)
+		conn, err := net.DialUDP(udpTransport, nil, resolveAddr)
 		if err != nil {
 			t.Errorf("UDP Collecting Process does not start correctly.")
 		}
@@ -253,12 +250,9 @@ func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 }
 
 func TestTCPCollectingProcess_ReceiveDataRecord(t *testing.T) {
-	address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      tcpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   false,
@@ -290,12 +284,9 @@ func TestTCPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 }
 
 func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
-	address, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      udpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   false,
@@ -303,11 +294,11 @@ func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 		ServerKey:     nil,
 	}
 	cp, err := InitCollectingProcess(input)
-	// Add the templates before sending data record
-	cp.addTemplate(uint32(1), uint16(256), elementsWithValue)
 	if err != nil {
 		t.Fatalf("UDP Collecting Process does not start correctly: %v", err)
 	}
+	// Add the templates before sending data record
+	cp.addTemplate(uint32(1), uint16(256), elementsWithValue)
 
 	go cp.Start()
 	// wait until collector is ready
@@ -318,7 +309,7 @@ func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 		if err != nil {
 			t.Errorf("UDP Address cannot be resolved.")
 		}
-		conn, err := net.DialUDP("udp", nil, resolveAddr)
+		conn, err := net.DialUDP(udpTransport, nil, resolveAddr)
 		if err != nil {
 			t.Errorf("UDP Collecting Process does not start correctly.")
 		}
@@ -330,19 +321,19 @@ func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 }
 
 func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
-	address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      tcpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   false,
 		ServerCert:    nil,
 		ServerKey:     nil,
 	}
-	cp, _ := InitCollectingProcess(input)
+	cp, err := InitCollectingProcess(input)
+	if err != nil {
+		t.Fatalf("Collecting Process does not start correctly: %v", err)
+	}
 	go func() {
 		// wait until collector is ready
 		waitForCollectorReady(t, cp)
@@ -368,19 +359,19 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 }
 
 func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {
-	address, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      udpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   false,
 		ServerCert:    nil,
 		ServerKey:     nil,
 	}
-	cp, _ := InitCollectingProcess(input)
+	cp, err := InitCollectingProcess(input)
+	if err != nil {
+		t.Fatalf("Collecting Process does not start correctly: %v", err)
+	}
 	go cp.Start()
 	// wait until collector is ready
 	waitForCollectorReady(t, cp)
@@ -390,7 +381,7 @@ func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {
 		if err != nil {
 			t.Errorf("UDP Address cannot be resolved.")
 		}
-		conn, err := net.DialUDP("udp", nil, resolveAddr)
+		conn, err := net.DialUDP(udpTransport, nil, resolveAddr)
 		if err != nil {
 			t.Errorf("UDP Collecting Process does not start correctly.")
 		}
@@ -402,7 +393,7 @@ func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {
 		if err != nil {
 			t.Errorf("UDP Address cannot be resolved.")
 		}
-		conn, err := net.DialUDP("udp", nil, resolveAddr)
+		conn, err := net.DialUDP(udpTransport, nil, resolveAddr)
 		if err != nil {
 			t.Errorf("UDP Collecting Process does not start correctly.")
 		}
@@ -421,7 +412,7 @@ func TestCollectingProcess_DecodeTemplateRecord(t *testing.T) {
 	cp := CollectingProcess{}
 	cp.templatesMap = make(map[uint32]map[uint16][]*entities.InfoElement)
 	cp.mutex = sync.RWMutex{}
-	address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	address, err := net.ResolveTCPAddr(tcpTransport, hostPort)
 	if err != nil {
 		t.Error(err)
 	}
@@ -462,7 +453,7 @@ func TestCollectingProcess_DecodeDataRecord(t *testing.T) {
 	cp := CollectingProcess{}
 	cp.templatesMap = make(map[uint32]map[uint16][]*entities.InfoElement)
 	cp.mutex = sync.RWMutex{}
-	address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	address, err := net.ResolveTCPAddr(tcpTransport, hostPort)
 	if err != nil {
 		t.Error(err)
 	}
@@ -495,12 +486,9 @@ func TestCollectingProcess_DecodeDataRecord(t *testing.T) {
 }
 
 func TestUDPCollectingProcess_TemplateExpire(t *testing.T) {
-	address, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      udpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   1,
 		IsEncrypted:   false,
@@ -520,7 +508,7 @@ func TestUDPCollectingProcess_TemplateExpire(t *testing.T) {
 		if err != nil {
 			t.Errorf("UDP Address cannot be resolved.")
 		}
-		conn, err := net.DialUDP("udp", nil, resolveAddr)
+		conn, err := net.DialUDP(udpTransport, nil, resolveAddr)
 		if err != nil {
 			t.Errorf("UDP Collecting Process does not start correctly.")
 		}
@@ -542,12 +530,9 @@ func TestUDPCollectingProcess_TemplateExpire(t *testing.T) {
 }
 
 func TestTLSCollectingProcess(t *testing.T) {
-	address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      tcpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   true,
@@ -593,12 +578,9 @@ func TestTLSCollectingProcess(t *testing.T) {
 }
 
 func TestDTLSCollectingProcess(t *testing.T) {
-	address, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Error(err)
-	}
 	input := CollectorInput{
-		Address:       address,
+		Address:       hostPort,
+		Protocol:      udpTransport,
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   true,
@@ -621,7 +603,6 @@ func TestDTLSCollectingProcess(t *testing.T) {
 		}
 		config := &dtls.Config{RootCAs: roots,
 			ExtendedMasterSecret: dtls.RequireExtendedMasterSecret}
-
 		conn, err := dtls.Dial("udp", collectorAddr, config)
 		if err != nil {
 			t.Error(err)

--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -150,7 +150,8 @@ func TestExportingProcess_SendingTemplateRecordToLocalTCPServer(t *testing.T) {
 
 	// Create exporter using local server info
 	input := ExporterInput{
-		CollectorAddr:       listener.Addr(),
+		CollectorAddress:    listener.Addr().String(),
+		CollectorProtocol:   listener.Addr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
 		PathMTU:             0,
@@ -226,7 +227,8 @@ func TestExportingProcess_SendingTemplateRecordToLocalUDPServer(t *testing.T) {
 
 	// Create exporter using local server info
 	input := ExporterInput{
-		CollectorAddr:       conn.LocalAddr(),
+		CollectorAddress:    conn.LocalAddr().String(),
+		CollectorProtocol:   conn.LocalAddr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      1,
 		PathMTU:             0,
@@ -306,7 +308,8 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 
 	// Create exporter using local server info
 	input := ExporterInput{
-		CollectorAddr:       listener.Addr(),
+		CollectorAddress:    listener.Addr().String(),
+		CollectorProtocol:   listener.Addr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
 		PathMTU:             0,
@@ -402,7 +405,8 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 
 	// Create exporter using local server info
 	input := ExporterInput{
-		CollectorAddr:       conn.LocalAddr(),
+		CollectorAddress:    conn.LocalAddr().String(),
+		CollectorProtocol:   conn.LocalAddr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
 		PathMTU:             0,
@@ -508,7 +512,8 @@ func TestExportingProcessWithTLS(t *testing.T) {
 
 	// Create exporter using local server info
 	input := ExporterInput{
-		CollectorAddr:       listener.Addr(),
+		CollectorAddress:    listener.Addr().String(),
+		CollectorProtocol:   listener.Addr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
 		IsEncrypted:         true,
@@ -590,7 +595,8 @@ func TestExportingProcessWithDTLS(t *testing.T) {
 
 	// Create exporter using local server info
 	input := ExporterInput{
-		CollectorAddr:       listener.Addr(),
+		CollectorAddress:    listener.Addr().String(),
+		CollectorProtocol:   listener.Addr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
 		IsEncrypted:         true,
@@ -644,7 +650,8 @@ func TestExportingProcess_GetMsgSizeLimit(t *testing.T) {
 	defer conn.Close()
 	// Create exporter using local server info
 	input := ExporterInput{
-		CollectorAddr:       conn.LocalAddr(),
+		CollectorAddress:    conn.LocalAddr().String(),
+		CollectorProtocol:   conn.LocalAddr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      1,
 		PathMTU:             0,

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -121,7 +121,8 @@ func TestCollectorToIntermediate(t *testing.T) {
 	}
 	// Initialize aggregation process and collecting process
 	cpInput := collector.CollectorInput{
-		Address:       address,
+		Address:       address.String(),
+		Protocol:      address.Network(),
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   false,

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -241,7 +241,8 @@ func testExporterToCollector(address net.Addr, isMultipleRecord bool, isEncrypte
 	// Initialize collecting process
 	messages := make([]*entities.Message, 0)
 	cpInput := collector.CollectorInput{
-		Address:       address,
+		Address:       address.String(),
+		Protocol:      address.Network(),
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   isEncrypted,
@@ -264,7 +265,8 @@ func testExporterToCollector(address net.Addr, isMultipleRecord bool, isEncrypte
 	go func() { // Start exporting process in go routine
 		waitForCollectorReady(t, cp)
 		epInput := exporter.ExporterInput{
-			CollectorAddr:       cp.GetAddress(),
+			CollectorAddress:    cp.GetAddress().String(),
+			CollectorProtocol:   cp.GetAddress().Network(),
 			ObservationDomainID: 1,
 			TempRefTimeout:      0,
 			PathMTU:             0,


### PR DESCRIPTION
Instead of accepting resolved TCP/UDP addresses, exporting and
collecting process takes hostPort and protocol string inputs and
do the addressing resolver job internally to make it easier for the
user.

Fixes #121 