### PR TITLE
Modify address resolution method in exporter and collector

### DIFF
--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -68,6 +68,7 @@ type CollectorInput struct {
 	CACert     []byte
 	ServerCert []byte
 	ServerKey  []byte
+	IsIPv6     bool
 }
 
 type clientHandler struct {
@@ -78,10 +79,14 @@ type clientHandler struct {
 func InitCollectingProcess(input CollectorInput) (*CollectingProcess, error) {
 	var address net.Addr
 	var err error
+	collectorAddress, err := util.ResolveDNSAddress(input.Address, input.IsIPv6)
+	if err != nil {
+		return nil, err
+	}
 	if input.Protocol == "tcp" {
-		address, err = net.ResolveTCPAddr(input.Protocol, input.Address)
+		address, err = net.ResolveTCPAddr(input.Protocol, collectorAddress)
 	} else if input.Protocol == "udp" {
-		address, err = net.ResolveUDPAddr(input.Protocol, input.Address)
+		address, err = net.ResolveUDPAddr(input.Protocol, collectorAddress)
 	} else {
 		return nil, fmt.Errorf("collecting process with protocol %s is not supported", input.Protocol)
 	}


### PR DESCRIPTION
Add DNS resolution in exporter and collector, remove the resolution for tls address because tls will use DNS name for validating certificates.