### PR TITLE
Fix standalone collector issue

### DIFF
--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -55,7 +55,7 @@ func initLoggingToFile(fs *pflag.FlagSet) {
 }
 
 func addIPFIXFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&IPFIXAddr, "ipfix.addr", "", "IPFIX collector address")
+	fs.StringVar(&IPFIXAddr, "ipfix.addr", "0.0.0.0", "IPFIX collector address")
 	fs.Uint16Var(&IPFIXPort, "ipfix.port", 4739, "IPFIX collector port")
 	fs.StringVar(&IPFIXTransport, "ipfix.transport", "tcp", "IPFIX collector transport layer")
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -61,7 +61,7 @@ func ResolveDNSAddress(address string, isIPv6 bool) (string, error) {
 	addr := address[:portIndex]
 	addr = strings.Replace(addr, "[", "", -1)
 	addr = strings.Replace(addr, "]", "", -1)
-	if ipAddr := net.ParseIP(addr); ipAddr == nil { // resolve DNS name
+	if ipAddr := net.ParseIP(addr); ipAddr == nil && len(addr) != 0 { // resolve DNS name
 		hostIPs, err := net.LookupIP(addr)
 		if err != nil {
 			if !isIPv6 {


### PR DESCRIPTION
Standalone collector takes empty string as address input, which causes the ResolveDNSAddress to throw an error. 