### PR TITLE
Add methods to Set Interface

### DIFF
--- a/pkg/entities/message_test.go
+++ b/pkg/entities/message_test.go
@@ -23,7 +23,8 @@ import (
 )
 
 func TestMessage_SetAndGetFunctions(t *testing.T) {
-	set := NewSet(Data, 257, false)
+	newSet := NewSet(false)
+	newSet.PrepareSet(Data, testTemplateID)
 
 	message := NewMessage(false)
 	message.CreateHeader()
@@ -46,8 +47,8 @@ func TestMessage_SetAndGetFunctions(t *testing.T) {
 	assert.Equal(t, binary.BigEndian.Uint32(message.GetMsgBuffer().Bytes()[4:8]), currTimeInUnixSecs)
 	message.SetExportAddress("127.0.0.1")
 	assert.Equal(t, message.GetExportAddress(), "127.0.0.1")
-	message.AddSet(set)
-	assert.Equal(t, message.GetSet(), set)
+	message.AddSet(newSet)
+	assert.Equal(t, message.GetSet(), newSet)
 	message.ResetMsgBuffer()
 	assert.Equal(t, message.GetMsgBufferLen(), 0)
 }

--- a/pkg/entities/set.go
+++ b/pkg/entities/set.go
@@ -41,7 +41,8 @@ const (
 )
 
 type Set interface {
-	GetBuffLen() int
+	PrepareSet(setType ContentType, templateID uint16) error
+	ResetSet()
 	GetBuffer() *bytes.Buffer
 	GetSetType() ContentType
 	UpdateLenInHeader()
@@ -58,22 +59,31 @@ type set struct {
 	isDecoding bool
 }
 
-func NewSet(setType ContentType, templateID uint16, isDecoding bool) Set {
-	set := &set{
+func NewSet(isDecoding bool) Set {
+	return &set{
 		buffer:     &bytes.Buffer{},
-		setType:    setType,
 		records:    make([]Record, 0),
 		isDecoding: isDecoding,
 	}
-	if !isDecoding {
-		// Create the set header and append it when encoding
-		set.createHeader(setType, templateID)
-	}
-	return set
 }
 
-func (s *set) GetBuffLen() int {
-	return s.buffer.Len()
+func (s *set) PrepareSet(setType ContentType, templateID uint16) error {
+	if setType == Undefined {
+		return fmt.Errorf("set type is not properly defined")
+	} else {
+		s.setType = setType
+	}
+	if !s.isDecoding {
+		// Create the set header and append it when encoding
+		return s.createHeader(s.setType, templateID)
+	}
+	return nil
+}
+
+func (s *set) ResetSet() {
+	s.buffer.Reset()
+	s.setType = Undefined
+	s.records = s.records[:0]
 }
 
 func (s *set) GetBuffer() *bytes.Buffer {
@@ -98,6 +108,8 @@ func (s *set) AddRecord(elements []*InfoElementWithValue, templateID uint16) err
 		record = NewDataRecord(templateID)
 	} else if s.setType == Template {
 		record = NewTemplateRecord(uint16(len(elements)), templateID)
+	} else {
+		return fmt.Errorf("set type is not supported")
 	}
 	record.PrepareRecord()
 	for _, element := range elements {
@@ -126,13 +138,15 @@ func (s *set) GetNumberOfRecords() uint32 {
 	return uint32(len(s.records))
 }
 
-func (s *set) createHeader(setType ContentType, templateID uint16) {
+func (s *set) createHeader(setType ContentType, templateID uint16) error {
 	header := make([]byte, 4)
 	if setType == Template {
 		binary.BigEndian.PutUint16(header[0:2], TemplateSetID)
 	} else if setType == Data {
 		binary.BigEndian.PutUint16(header[0:2], templateID)
 	}
-	// TODO: Handle this error in a future PR.
-	s.buffer.Write(header)
+	if _, err := s.buffer.Write(header); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -8,73 +8,96 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testTemplateID = uint16(256)
+)
+
 func TestAddRecordIPv4Addresses(t *testing.T) {
-	// Test with template set
+	// Test with template encodingSet
 	elements := make([]*InfoElementWithValue, 0)
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
-	set := NewSet(Template, uint16(256), true)
-	set.AddRecord(elements, 256)
-	_, exist := set.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
+	encodingSet := NewSet(false)
+	err := encodingSet.PrepareSet(Template, testTemplateID)
+	assert.NoError(t, err)
+	encodingSet.AddRecord(elements, 256)
+	_, exist := encodingSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
-	_, exist = set.GetRecords()[0].GetInfoElementWithValue("destinationIPv4Address")
+	_, exist = encodingSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv4Address")
 	assert.Equal(t, true, exist)
-	// Test with data set
-	set = NewSet(Data, uint16(256), false)
+	encodingSet.ResetSet()
+	// Test with data encodingSet
+	err = encodingSet.PrepareSet(Data, testTemplateID)
+	assert.NoError(t, err)
 	elements = make([]*InfoElementWithValue, 0)
 	ie1 = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("10.0.0.2"))
 	elements = append(elements, ie1, ie2)
-	set.AddRecord(elements, 256)
-	infoElementWithValue, _ := set.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
+	err = encodingSet.AddRecord(elements, 256)
+	assert.NoError(t, err)
+	infoElementWithValue, _ := encodingSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x1}), infoElementWithValue.Value)
-	infoElementWithValue, _ = set.GetRecords()[0].GetInfoElementWithValue("destinationIPv4Address")
+	infoElementWithValue, _ = encodingSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv4Address")
 	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x2}), infoElementWithValue.Value)
 }
 
 func TestAddRecordIPv6Addresses(t *testing.T) {
-	// Test with template set
+	// Test with template record
 	elements := make([]*InfoElementWithValue, 0)
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv6Address", 27, 19, 0, 16), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), nil)
 	elements = append(elements, ie1, ie2)
-	set := NewSet(Template, uint16(256), true)
-	set.AddRecord(elements, 256)
-	_, exist := set.GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
+	newSet := NewSet(false)
+	err := newSet.PrepareSet(Template, testTemplateID)
+	assert.NoError(t, err)
+	newSet.AddRecord(elements, 256)
+	_, exist := newSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
 	assert.Equal(t, true, exist)
-	_, exist = set.GetRecords()[0].GetInfoElementWithValue("destinationIPv6Address")
+	_, exist = newSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv6Address")
 	assert.Equal(t, true, exist)
-	// Test with data set
-	set = NewSet(Data, uint16(256), false)
+	newSet.ResetSet()
+	// Test with data record
+	err = newSet.PrepareSet(Data, testTemplateID)
+	assert.NoError(t, err)
 	elements = make([]*InfoElementWithValue, 0)
 	ie1 = NewInfoElementWithValue(NewInfoElement("sourceIPv6Address", 27, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
 	elements = append(elements, ie1, ie2)
-	set.AddRecord(elements, 256)
-	infoElementWithValue, _ := set.GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
+	newSet.AddRecord(elements, 256)
+	infoElementWithValue, _ := newSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
 	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}), infoElementWithValue.Value)
-	infoElementWithValue, _ = set.GetRecords()[0].GetInfoElementWithValue("destinationIPv6Address")
+	infoElementWithValue, _ = newSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv6Address")
 	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfc}), infoElementWithValue.Value)
 }
 
 func TestGetSetType(t *testing.T) {
-	assert.Equal(t, Template, NewSet(Template, uint16(256), true).GetSetType())
-	assert.Equal(t, Data, NewSet(Data, uint16(258), true).GetSetType())
+	newSet := NewSet(true)
+	_ = newSet.PrepareSet(Template, testTemplateID)
+	assert.Equal(t, Template, newSet.GetSetType())
+	newSet.ResetSet()
+	_ = newSet.PrepareSet(Data, testTemplateID)
+	assert.Equal(t, Data, newSet.GetSetType())
 }
 
 func TestGetBuffer(t *testing.T) {
-	assert.Equal(t, 0, NewSet(Template, uint16(256), true).GetBuffer().Len())
-	assert.Equal(t, 4, NewSet(Template, uint16(257), false).GetBuffer().Len())
-	assert.Equal(t, 0, NewSet(Data, uint16(258), true).GetBuffer().Len())
-	assert.Equal(t, 4, NewSet(Data, uint16(259), false).GetBuffer().Len())
-}
+	decodingSet := NewSet(true)
+	err := decodingSet.PrepareSet(Template, testTemplateID)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, decodingSet.GetBuffer().Len())
+	decodingSet.ResetSet()
+	err = decodingSet.PrepareSet(Template, uint16(258))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, decodingSet.GetBuffer().Len())
 
-func TestGetBuffLen(t *testing.T) {
-	assert.Equal(t, 0, NewSet(Template, uint16(256), true).GetBuffLen())
-	assert.Equal(t, 4, NewSet(Template, uint16(257), false).GetBuffLen())
-	assert.Equal(t, 0, NewSet(Data, uint16(258), true).GetBuffLen())
-	assert.Equal(t, 4, NewSet(Data, uint16(259), false).GetBuffLen())
+	encodingSet := NewSet(false)
+	err = encodingSet.PrepareSet(Template, uint16(257))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, encodingSet.GetBuffer().Len())
+	encodingSet.ResetSet()
+	err = encodingSet.PrepareSet(Template, uint16(257))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, encodingSet.GetBuffer().Len())
 }
 
 func TestGetRecords(t *testing.T) {
@@ -82,9 +105,11 @@ func TestGetRecords(t *testing.T) {
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
-	set := NewSet(Template, uint16(256), true)
-	set.AddRecord(elements, 256)
-	assert.Equal(t, 2, len(set.GetRecords()[0].GetOrderedElementList()))
+	newSet := NewSet(true)
+	err := newSet.PrepareSet(Template, testTemplateID)
+	assert.NoError(t, err)
+	newSet.AddRecord(elements, testTemplateID)
+	assert.Equal(t, 2, len(newSet.GetRecords()[0].GetOrderedElementList()))
 }
 
 func TestGetNumberOfRecords(t *testing.T) {
@@ -92,9 +117,11 @@ func TestGetNumberOfRecords(t *testing.T) {
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
-	set := NewSet(Template, uint16(256), true)
-	set.AddRecord(elements, 256)
-	assert.Equal(t, uint32(1), set.GetNumberOfRecords())
+	newSet := NewSet(true)
+	err := newSet.PrepareSet(Template, testTemplateID)
+	assert.NoError(t, err)
+	newSet.AddRecord(elements, testTemplateID)
+	assert.Equal(t, uint32(1), newSet.GetNumberOfRecords())
 }
 
 func TestSet_UpdateLenInHeader(t *testing.T) {
@@ -102,15 +129,19 @@ func TestSet_UpdateLenInHeader(t *testing.T) {
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
-	setForDecoding := NewSet(Template, uint16(256), true)
-	setForEncoding := NewSet(Template, uint16(257), false)
-	setForEncoding.AddRecord(elements, 256)
-	assert.Equal(t, 0, setForDecoding.GetBuffLen())
-	assert.Equal(t, 16, setForEncoding.GetBuffLen())
+	setForDecoding := NewSet(true)
+	err := setForDecoding.PrepareSet(Template, testTemplateID)
+	assert.NoError(t, err)
+	setForEncoding := NewSet(false)
+	err = setForEncoding.PrepareSet(Template, testTemplateID)
+	assert.NoError(t, err)
+	setForEncoding.AddRecord(elements, testTemplateID)
+	assert.Equal(t, 0, setForDecoding.GetBuffer().Len())
+	assert.Equal(t, 16, setForEncoding.GetBuffer().Len())
 	setForDecoding.UpdateLenInHeader()
 	setForEncoding.UpdateLenInHeader()
 	// Nothing should be written in setForDecoding
-	assert.Equal(t, 0, setForDecoding.GetBuffLen())
+	assert.Equal(t, 0, setForDecoding.GetBuffer().Len())
 	// Check the bytes in the header for set length
-	assert.Equal(t, uint16(setForEncoding.GetBuffLen()), binary.BigEndian.Uint16(setForEncoding.GetBuffer().Bytes()[2:4]))
+	assert.Equal(t, uint16(setForEncoding.GetBuffer().Len()), binary.BigEndian.Uint16(setForEncoding.GetBuffer().Bytes()[2:4]))
 }

--- a/pkg/entities/testing/mock_set.go
+++ b/pkg/entities/testing/mock_set.go
@@ -62,20 +62,6 @@ func (mr *MockSetMockRecorder) AddRecord(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRecord", reflect.TypeOf((*MockSet)(nil).AddRecord), arg0, arg1)
 }
 
-// GetBuffLen mocks base method
-func (m *MockSet) GetBuffLen() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBuffLen")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// GetBuffLen indicates an expected call of GetBuffLen
-func (mr *MockSetMockRecorder) GetBuffLen() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuffLen", reflect.TypeOf((*MockSet)(nil).GetBuffLen))
-}
-
 // GetBuffer mocks base method
 func (m *MockSet) GetBuffer() *bytes.Buffer {
 	m.ctrl.T.Helper()
@@ -130,6 +116,32 @@ func (m *MockSet) GetSetType() entities.ContentType {
 func (mr *MockSetMockRecorder) GetSetType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSetType", reflect.TypeOf((*MockSet)(nil).GetSetType))
+}
+
+// PrepareSet mocks base method
+func (m *MockSet) PrepareSet(arg0 entities.ContentType, arg1 uint16) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareSet", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrepareSet indicates an expected call of PrepareSet
+func (mr *MockSetMockRecorder) PrepareSet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareSet", reflect.TypeOf((*MockSet)(nil).PrepareSet), arg0, arg1)
+}
+
+// ResetSet mocks base method
+func (m *MockSet) ResetSet() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResetSet")
+}
+
+// ResetSet indicates an expected call of ResetSet
+func (mr *MockSetMockRecorder) ResetSet() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetSet", reflect.TypeOf((*MockSet)(nil).ResetSet))
 }
 
 // UpdateLenInHeader mocks base method

--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -164,7 +164,9 @@ func TestExportingProcess_SendingTemplateRecordToLocalTCPServer(t *testing.T) {
 
 	// Create template record with two fields
 	templateID := exporter.NewTemplateID()
-	templateSet := entities.NewSet(entities.Template, templateID, false)
+	templateSet := entities.NewSet(false)
+	err = templateSet.PrepareSet(entities.Template, templateID)
+	assert.NoError(t, err)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	element, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
@@ -241,7 +243,9 @@ func TestExportingProcess_SendingTemplateRecordToLocalUDPServer(t *testing.T) {
 
 	// Create template record with two fields
 	templateID := exporter.NewTemplateID()
-	templateSet := entities.NewSet(entities.Template, templateID, false)
+	templateSet := entities.NewSet(false)
+	err = templateSet.PrepareSet(entities.Template, templateID)
+	assert.NoError(t, err)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	element, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
@@ -337,7 +341,9 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 	exporter.updateTemplate(templateID, []*entities.InfoElementWithValue{element1, element2}, 8)
 
 	// Create data set with 1 data record
-	dataSet := entities.NewSet(entities.Data, templateID, false)
+	dataSet := entities.NewSet(false)
+	err = dataSet.PrepareSet(entities.Data, templateID)
+	assert.NoError(t, err)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	element, err = registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
@@ -366,7 +372,9 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 
 	// Create data set with multiple data records to test invalid message length
 	// logic for TCP transport.
-	dataSet = entities.NewSet(entities.Data, templateID, false)
+	dataSet.ResetSet()
+	err = dataSet.PrepareSet(entities.Data, templateID)
+	assert.NoError(t, err)
 	for i := 0; i < 10000; i++ {
 		err := dataSet.AddRecord(elements, templateID)
 		assert.NoError(t, err)
@@ -434,7 +442,9 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	exporter.updateTemplate(templateID, []*entities.InfoElementWithValue{element1, element2}, 8)
 
 	// Create data set with 1 data record
-	dataSet := entities.NewSet(entities.Data, templateID, false)
+	dataSet := entities.NewSet(false)
+	err = dataSet.PrepareSet(entities.Data, templateID)
+	assert.NoError(t, err)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	element, err = registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
@@ -463,7 +473,9 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 
 	// Create data set with multiple data records to test invalid message length
 	// logic for UDP transport.
-	dataSet = entities.NewSet(entities.Data, templateID, false)
+	dataSet.ResetSet()
+	err = dataSet.PrepareSet(entities.Data, templateID)
+	assert.NoError(t, err)
 	for i := 0; i < 100; i++ {
 		dataSet.AddRecord(elements, templateID)
 	}
@@ -527,7 +539,9 @@ func TestExportingProcessWithTLS(t *testing.T) {
 
 	// Create template record with two fields
 	templateID := exporter.NewTemplateID()
-	templateSet := entities.NewSet(entities.Template, templateID, false)
+	templateSet := entities.NewSet(false)
+	err = templateSet.PrepareSet(entities.Template, templateID)
+	assert.NoError(t, err)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	element, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
@@ -610,7 +624,9 @@ func TestExportingProcessWithDTLS(t *testing.T) {
 
 	// Create template record with two fields
 	templateID := exporter.NewTemplateID()
-	templateSet := entities.NewSet(entities.Template, templateID, false)
+	templateSet := entities.NewSet(false)
+	err = templateSet.PrepareSet(entities.Template, templateID)
+	assert.NoError(t, err)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	element, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -54,8 +54,13 @@ func init() {
 	registry.LoadRegistry()
 }
 
+const (
+	testTemplateID = uint16(256)
+)
+
 func createMsgwithTemplateSet(isIPv6 bool) *entities.Message {
-	set := entities.NewSet(entities.Template, 256, true)
+	set := entities.NewSet(true)
+	set.PrepareSet(entities.Template, testTemplateID)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), nil)
 	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), nil)
@@ -94,7 +99,8 @@ func createMsgwithTemplateSet(isIPv6 bool) *entities.Message {
 
 // TODO:Cleanup this function using a loop, to make it easy to add elements for testing.
 func createDataMsgForSrc(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedRecord bool) *entities.Message {
-	set := entities.NewSet(entities.Data, 256, true)
+	set := entities.NewSet(true)
+	set.PrepareSet(entities.Data, testTemplateID)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	srcPort := new(bytes.Buffer)
 	dstPort := new(bytes.Buffer)
@@ -197,7 +203,8 @@ func createDataMsgForSrc(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 }
 
 func createDataMsgForDst(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedRecord bool) *entities.Message {
-	set := entities.NewSet(entities.Data, 256, true)
+	set := entities.NewSet(true)
+	set.PrepareSet(entities.Data, testTemplateID)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	srcPort := new(bytes.Buffer)
 	dstPort := new(bytes.Buffer)

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -429,7 +429,8 @@ func testExporterToCollector(address net.Addr, isMultipleRecord bool, isEncrypte
 }
 
 func createTemplateSet(templateID uint16) entities.Set {
-	templateSet := entities.NewSet(entities.Template, templateID, false)
+	templateSet := entities.NewSet(false)
+	templateSet.PrepareSet(entities.Template, templateID)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	for _, name := range fields {
 		element, _ := registry.GetInfoElement(name, registry.IANAEnterpriseID)
@@ -451,7 +452,8 @@ func createTemplateSet(templateID uint16) entities.Set {
 }
 
 func createDataSet(templateID uint16, isMultipleRecord bool) entities.Set {
-	dataSet := entities.NewSet(entities.Data, templateID, false)
+	dataSet := entities.NewSet(false)
+	dataSet.PrepareSet(entities.Data, templateID)
 	elements := make([]*entities.InfoElementWithValue, 0)
 	for _, name := range fields {
 		element, _ := registry.GetInfoElement(name, registry.IANAEnterpriseID)


### PR DESCRIPTION
Add PrepareSet and ResetSet methods to Set interface.
This is to avoid multiple allocations by the user, for example, when
exporting sets user could allocate the Set only once and re-use it
for exporting multiple records.

PS: In Antrea, the main user of go-ipfix library, this change enables to write better unit tests. 