### PR TITLE
Simplify address input consumption

### DIFF
--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -367,7 +367,7 @@ func TestCollectingProcess_DecodeTemplateRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp.address = address
+	cp.netAddress = address
 	cp.messageChan = make(chan *entities.Message)
 	go func() { // remove the message from the message channel
 		for range cp.GetMsgChan() {
@@ -408,7 +408,7 @@ func TestCollectingProcess_DecodeDataRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cp.address = address
+	cp.netAddress = address
 	cp.messageChan = make(chan *entities.Message)
 	go func() { // remove the message from the message channel
 		for range cp.GetMsgChan() {

--- a/pkg/collector/tcp.go
+++ b/pkg/collector/tcp.go
@@ -20,21 +20,21 @@ func (cp *CollectingProcess) startTCPServer() {
 			klog.Error(err)
 			return
 		}
-		listener, err = tls.Listen("tcp", cp.address.String(), config)
+		listener, err = tls.Listen("tcp", cp.address, config)
 		if err != nil {
-			klog.Errorf("Cannot start tls collecting process on %s: %v", cp.address.String(), err)
+			klog.Errorf("Cannot start tls collecting process on %s: %v", cp.address, err)
 			return
 		}
 		cp.updateAddress(listener.Addr())
-		klog.Infof("Start tls collecting process on %s", cp.address.String())
+		klog.Infof("Started TLS collecting process on %s", cp.address)
 	} else {
-		listener, err = net.Listen("tcp", cp.address.String())
+		listener, err = net.Listen("tcp", cp.address)
 		if err != nil {
-			klog.Errorf("Cannot start collecting process on %s: %v", cp.address.String(), err)
+			klog.Errorf("Cannot start collecting process on %s: %v", cp.address, err)
 			return
 		}
 		cp.updateAddress(listener.Addr())
-		klog.Infof("Start %s collecting process on %s", cp.address.Network(), cp.address.String())
+		klog.Infof("Start TCP collecting process on %s", cp.address)
 	}
 
 	go func() {
@@ -42,7 +42,7 @@ func (cp *CollectingProcess) startTCPServer() {
 		for {
 			conn, err := listener.Accept()
 			if err != nil {
-				klog.Errorf("Cannot start collecting process on %s: %v", cp.address.String(), err)
+				klog.Errorf("Cannot start collecting process on %s: %v", cp.address, err)
 				return
 			}
 			go cp.handleTCPClient(conn)

--- a/pkg/collector/udp.go
+++ b/pkg/collector/udp.go
@@ -33,7 +33,7 @@ func (cp *CollectingProcess) startUDPServer() {
 	var err error
 	var conn net.Conn
 	var wg sync.WaitGroup
-	address, err := net.ResolveUDPAddr(cp.address.Network(), cp.address.String())
+	address, err := net.ResolveUDPAddr(cp.protocol, cp.address)
 	if err != nil {
 		klog.Error(err)
 		return
@@ -57,7 +57,7 @@ func (cp *CollectingProcess) startUDPServer() {
 			return
 		}
 		cp.updateAddress(listener.Addr())
-		klog.Infof("Start dtls collecting process on %s", cp.address.String())
+		klog.Infof("Start dtls collecting process on %s", cp.address)
 		conn, err = listener.Accept()
 		if err != nil {
 			klog.Error(err)
@@ -92,7 +92,7 @@ func (cp *CollectingProcess) startUDPServer() {
 			return
 		}
 		cp.updateAddress(conn.LocalAddr())
-		klog.Infof("Start %s collecting process on %s", cp.address.Network(), cp.address.String())
+		klog.Infof("Start UDP collecting process on %s", cp.address)
 		defer conn.Close()
 		go func() {
 			for {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,8 +18,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"net"
-	"strings"
 )
 
 // Encode writes the multiple inputs of different possible datatypes to the io writer.
@@ -51,34 +49,4 @@ func Decode(buffer io.Reader, byteOrder binary.ByteOrder, outputs ...interface{}
 		}
 	}
 	return nil
-}
-
-// ResolveDNSAddress gets ip:port or dns:port as input and resolves the dns name if exists
-// then return ip:port
-func ResolveDNSAddress(address string, isIPv6 bool) (string, error) {
-	portIndex := strings.LastIndex(address, ":")
-	port := address[portIndex+1:]
-	addr := address[:portIndex]
-	addr = strings.Replace(addr, "[", "", -1)
-	addr = strings.Replace(addr, "]", "", -1)
-	if ipAddr := net.ParseIP(addr); ipAddr == nil && len(addr) != 0 { // resolve DNS name
-		hostIPs, err := net.LookupIP(addr)
-		if err != nil {
-			if !isIPv6 {
-				if ip := hostIPs[0].To4(); ip != nil {
-					return net.JoinHostPort(ip.String(), port), nil
-				} else {
-					return "", fmt.Errorf("cannot resolve %s to IPv4 address", address)
-				}
-			} else {
-				if ip := hostIPs[0].To16(); ip != nil {
-					return net.JoinHostPort(ip.String(), port), nil
-				} else {
-					return "", fmt.Errorf("cannot resolve %s to IPv6 address", address)
-				}
-			}
-		}
-		return "", err
-	}
-	return address, nil
 }


### PR DESCRIPTION
In exporting and collecting process, simplify the address input
consumption.

This is as per suggestions provided through Antrea PRs, who is the main user of go-ipfix library.