### PR TITLE
Fix the Set reset issue

### DIFF
--- a/pkg/entities/set.go
+++ b/pkg/entities/set.go
@@ -83,7 +83,8 @@ func (s *set) PrepareSet(setType ContentType, templateID uint16) error {
 func (s *set) ResetSet() {
 	s.buffer.Reset()
 	s.setType = Undefined
-	s.records = s.records[:0]
+	s.records = nil
+	s.records = make([]Record, 0)
 }
 
 func (s *set) GetBuffer() *bytes.Buffer {


### PR DESCRIPTION
Re-initialize record slice by making it nil for GC to clean
up previous records and references properly.
This led to the issue in Antrea: https://github.com/vmware-tanzu/antrea/issues/2035