### PR TITLE
Add new fields for Antrea registry

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -38,6 +38,13 @@ const (
 	FromExternal = uint8(4)
 )
 
+// enum for ingressNetworkPolicyRuleAction and egressNetworkPolicyRuleAction field in Antrea registry.
+const (
+	NetworkPolicyRuleActionAllow  = uint8(1)
+	NetworkPolicyRuleActionDrop   = uint8(2)
+	NetworkPolicyRuleActionReject = uint8(3)
+)
+
 // enum for flowEndReason field in IANA registry.
 // List of RFC supported reasons: https://www.iana.org/assignments/ipfix/ipfix.xhtml#ipfix-flow-end-reason
 const (

--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -36,4 +36,7 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 134,reversePacketDeltaCountFromDestinationNode,unsigned64,,current,,,,,,,,56506,
 135,reverseOctetDeltaCountFromDestinationNode,unsigned64,,current,,,,,,,,56506,
 136,tcpState,string,,current,,,,,,,,56506,
-137,flowType,unsigned8,,current,,,,,,,,56506,
+137,flowType,unsigned8,,current,The type of flow is based on the location of the source and destination Pods. Supported Types(uint8 value): IntraNode(1) InterNode(2) ToExternal(3) and FromExternal(4),,,,,,,56506,
+138,tcpStatePrevList,string,,current,,,,,,,,56506,
+139,ingressNetworkPolicyRuleAction,unsigned8,,current,Supported Actions(uint8 value): NetworkPolicyRuleActionAllow(1) NetworkPolicyRuleActionDrop(2) NetworkPolicyRuleActionReject(3),,,,,,,56506,
+140,egressNetworkPolicyRuleAction,unsigned8,,current,Supported Actions(uint8 value): NetworkPolicyRuleActionAllow(1) NetworkPolicyRuleActionDrop(2) NetworkPolicyRuleActionReject(3),,,,,,,56506,

--- a/pkg/registry/registry_antrea.go
+++ b/pkg/registry/registry_antrea.go
@@ -59,4 +59,7 @@ func loadAntreaRegistry() {
 	registerInfoElement(*entities.NewInfoElement("reverseOctetDeltaCountFromDestinationNode", 135, 4, 56506, 8), 56506)
 	registerInfoElement(*entities.NewInfoElement("tcpState", 136, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("flowType", 137, 1, 56506, 1), 56506)
+	registerInfoElement(*entities.NewInfoElement("tcpStatePrevList", 138, 13, 56506, 65535), 56506)
+	registerInfoElement(*entities.NewInfoElement("ingressNetworkPolicyRuleAction", 139, 1, 56506, 1), 56506)
+	registerInfoElement(*entities.NewInfoElement("egressNetworkPolicyRuleAction", 140, 1, 56506, 1), 56506)
 }


### PR DESCRIPTION
Add some information elements to Antrea registry to prepare support for tcp state transition and deny connection tracking in Antrea.