### PR TITLE
Revert klog to v1

### DIFF
--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/collector"
 	"github.com/vmware/go-ipfix/pkg/entities"

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 	google.golang.org/protobuf v1.26.0
 	k8s.io/apimachinery v0.18.4
 	k8s.io/component-base v0.18.4
-	k8s.io/klog/v2 v2.4.0
+	k8s.io/klog v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
-github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
-github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
@@ -301,8 +299,6 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-k8s.io/klog/v2 v2.4.0 h1:7+X0fUguPyrKEC4WjH8iGDg3laWgMo5tMnRTIGTTxGQ=
-k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/registry"

--- a/pkg/collector/tcp.go
+++ b/pkg/collector/tcp.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 )
 
 func (cp *CollectingProcess) startTCPServer() {

--- a/pkg/collector/udp.go
+++ b/pkg/collector/udp.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/pion/dtls/v2"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 )

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/pion/dtls/v2"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 )

--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/registry"

--- a/pkg/intermediate/worker.go
+++ b/pkg/intermediate/worker.go
@@ -1,7 +1,7 @@
 package intermediate
 
 import (
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 )

--- a/pkg/producer/convertor/test/flowtype1.go
+++ b/pkg/producer/convertor/test/flowtype1.go
@@ -17,7 +17,7 @@ package test
 import (
 	"net"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/producer/convertor"

--- a/pkg/producer/convertor/test/flowtype2.go
+++ b/pkg/producer/convertor/test/flowtype2.go
@@ -17,7 +17,7 @@ package test
 import (
 	"net"
 
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/producer/convertor"

--- a/pkg/producer/kafka.go
+++ b/pkg/producer/kafka.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"google.golang.org/protobuf/proto"
-	"k8s.io/klog/v2"
+	"k8s.io/klog"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/producer/convertor"


### PR DESCRIPTION
Revert klog from v2 to v1 to avoid version inconsistency in Antrea and changes for go-ipfix v0.5.x release. Will provide new tag for upgrading klog if this PR https://github.com/vmware-tanzu/antrea/pull/1973 is merged after bumping go-ipfix to v0.5.x