### PR TITLE
Aggregation process support for deny connections tracking

### DIFF
--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -26,12 +26,12 @@ var (
 		"destinationClusterIPv4",
 		"destinationClusterIPv6",
 		"destinationServicePort",
+		"ingressNetworkPolicyRuleAction",
 	}
 	nonStatsElementList = []string{
 		"flowEndSeconds",
 		"flowEndReason",
 		"tcpState",
-		"ingressNetworkPolicyRuleAction",
 	}
 	statsElementList = []string{
 		"packetTotalCount",

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -40,9 +40,10 @@ const (
 
 // enum for ingressNetworkPolicyRuleAction and egressNetworkPolicyRuleAction field in Antrea registry.
 const (
-	NetworkPolicyRuleActionAllow  = uint8(1)
-	NetworkPolicyRuleActionDrop   = uint8(2)
-	NetworkPolicyRuleActionReject = uint8(3)
+	NetworkPolicyRuleActionNoAction = uint8(0)
+	NetworkPolicyRuleActionAllow    = uint8(1)
+	NetworkPolicyRuleActionDrop     = uint8(2)
+	NetworkPolicyRuleActionReject   = uint8(3)
 )
 
 // enum for flowEndReason field in IANA registry.

--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -38,5 +38,5 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 136,tcpState,string,,current,,,,,,,,56506,
 137,flowType,unsigned8,,current,The type of flow is based on the location of the source and destination Pods. Supported Types(uint8 value): FlowTypeIntraNode(1) FlowTypeInterNode(2) FlowTypeToExternal(3) and FlowTypeFromExternal(4),,,,,,,56506,
 138,tcpStatePrevList,string,,current,,,,,,,,56506,
-139,ingressNetworkPolicyRuleAction,unsigned8,,current,Supported Actions(uint8 value): NetworkPolicyRuleActionAllow(1) NetworkPolicyRuleActionDrop(2) NetworkPolicyRuleActionReject(3),,,,,,,56506,
+139,ingressNetworkPolicyRuleAction,unsigned8,,current,Supported Actions(uint8 value): NetworkPolicyRuleActionNoAction(0) NetworkPolicyRuleActionAllow(1) NetworkPolicyRuleActionDrop(2) NetworkPolicyRuleActionReject(3),,,,,,,56506,
 140,egressNetworkPolicyRuleAction,unsigned8,,current,Supported Actions(uint8 value): NetworkPolicyRuleActionAllow(1) NetworkPolicyRuleActionDrop(2) NetworkPolicyRuleActionReject(3),,,,,,,56506,


### PR DESCRIPTION
Set correlation of inter-Node flows as not required for deny (drop/reject) egress network policy rule actions. Reason is that deny action will happen only on one node for egress network policy, so only record from source will be received.