### PR TITLE
Fix bug with upload release assets

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -9,21 +9,13 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
+      - uses: actions/checkout@v2
       - name: Build assets
-        uses: actions/checkout@v2
         env:
           TAG: ${{ github.ref }}
         run: |
           mkdir assets
           VERSION="${TAG:10}" ./hack/release/prepare-assets.sh ./assets
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
       - name: Upload ipfix-collector.yaml
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
To fix the error: a step cannot have both the `uses` and `run` keys. 

Fixes: #177 