### PR TITLE
Modify aggregation process to maintain record expiry data

### DIFF
--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -16,11 +16,13 @@ package intermediate
 
 import (
 	"bytes"
+	"container/heap"
 	"encoding/binary"
 	"fmt"
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -29,9 +31,17 @@ import (
 	"github.com/vmware/go-ipfix/pkg/util"
 )
 
+var (
+	MaxRetries    = 5
+	MinExpiryTime = 100 * time.Millisecond
+)
+
 type AggregationProcess struct {
 	// flowKeyRecordMap maps each connection (5-tuple) with its records
 	flowKeyRecordMap map[FlowKey]AggregationFlowRecord
+	// expirePriorityQueue helps to maintain a priority queue for the records given
+	// active expiry and inactive expiry timeouts.
+	expirePriorityQueue TimeToExpirePriorityQueue
 	// mutex allows multiple readers or one writer at the same time
 	mutex sync.RWMutex
 	// messageChan is the channel to receive the message
@@ -49,15 +59,26 @@ type AggregationProcess struct {
 	// TODO: Add checks to validate the lists inside such as no duplicates, order
 	// of stats etc.
 	aggregateElements *AggregationElements
+	// activeExpiryTimeout helps in identifying records that elapsed active expiry
+	// timeout. Active expiry timeout is a periodic expiry interval for every flow
+	// record in the aggregation record map.
+	activeExpiryTimeout time.Duration
+	// inactiveExpiryTimeout helps in identifying records that elapsed inactive expiry
+	// timeout. Inactive expiry timeout is an expiry interval that gets reset every
+	// time a new record is received for the existing record in the aggregation
+	// record map.
+	inactiveExpiryTimeout time.Duration
 	// stopChan is the channel to receive stop message
 	stopChan chan bool
 }
 
 type AggregationInput struct {
-	MessageChan       chan *entities.Message
-	WorkerNum         int
-	CorrelateFields   []string
-	AggregateElements *AggregationElements
+	MessageChan           chan *entities.Message
+	WorkerNum             int
+	CorrelateFields       []string
+	AggregateElements     *AggregationElements
+	ActiveExpiryTimeout   time.Duration
+	InactiveExpiryTimeout time.Duration
 }
 
 // InitAggregationProcess takes in message channel (e.g. from collector) as input
@@ -69,14 +90,22 @@ func InitAggregationProcess(input AggregationInput) (*AggregationProcess, error)
 	} else if input.WorkerNum <= 0 {
 		return nil, fmt.Errorf("worker number cannot be <= 0")
 	}
+	if input.AggregateElements != nil {
+		if (len(input.AggregateElements.StatsElements) != len(input.AggregateElements.AggregatedSourceStatsElements)) || (len(input.AggregateElements.StatsElements) != len(input.AggregateElements.AggregatedDestinationStatsElements)) {
+			return nil, fmt.Errorf("stats elements, source stats elements and destination stats elemenst length should be equal")
+		}
+	}
 	return &AggregationProcess{
 		make(map[FlowKey]AggregationFlowRecord),
+		make(TimeToExpirePriorityQueue, 0),
 		sync.RWMutex{},
 		input.MessageChan,
 		input.WorkerNum,
 		make([]*worker, 0),
 		input.CorrelateFields,
 		input.AggregateElements,
+		input.ActiveExpiryTimeout,
+		input.InactiveExpiryTimeout,
 		make(chan bool),
 	}, nil
 }
@@ -148,31 +177,93 @@ func (a *AggregationProcess) ForAllRecordsDo(callback FlowKeyRecordMapCallBack) 
 	return nil
 }
 
-// GetLastUpdatedTimeOfFlow provides the last updated time in the format of IPFIX
-// field "flowEndSeconds".
-func (a *AggregationProcess) GetLastUpdatedTimeOfFlow(flowKey FlowKey) (uint32, error) {
+func (a *AggregationProcess) deleteFlowKeyFromMap(flowKey FlowKey) error {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
-	record, exists := a.flowKeyRecordMap[flowKey]
-	if !exists {
-		return 0, fmt.Errorf("flow key is not present in the map")
-	}
-	flowEndField, exists := record.Record.GetInfoElementWithValue("flowEndSeconds")
-	if exists {
-		return flowEndField.Value.(uint32), nil
-	} else {
-		return 0, fmt.Errorf("flowEndSeconds field is not present in the record")
-	}
+	return a.deleteFlowKeyFromMapWithoutLock(flowKey)
 }
 
-func (a *AggregationProcess) DeleteFlowKeyFromMap(flowKey FlowKey) error {
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
+func (a *AggregationProcess) deleteFlowKeyFromMapWithoutLock(flowKey FlowKey) error {
 	_, exists := a.flowKeyRecordMap[flowKey]
 	if !exists {
-		return fmt.Errorf("flow key is not present in the map")
+		return fmt.Errorf("flow key %v is not present in the map", flowKey)
 	}
 	delete(a.flowKeyRecordMap, flowKey)
+	return nil
+}
+
+// GetExpiryFromExpirePriorityQueue returns the earliest timestamp (active expiry
+// or inactive expiry) from expire priority queue.
+func (a *AggregationProcess) GetExpiryFromExpirePriorityQueue() time.Duration {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	currTime := time.Now()
+	if a.expirePriorityQueue.Len() > 0 {
+		// Get the minExpireTime of the top item in expirePriorityQueue.
+		expiryDuration := MinExpiryTime + a.expirePriorityQueue.minExpireTime(0).Sub(currTime)
+		if expiryDuration < 0 {
+			return MinExpiryTime
+		}
+		return expiryDuration
+	}
+	if a.activeExpiryTimeout < a.inactiveExpiryTimeout {
+		return a.activeExpiryTimeout
+	}
+	return a.inactiveExpiryTimeout
+}
+
+func (a *AggregationProcess) ForAllExpiredFlowRecordsDo(callback FlowKeyRecordMapCallBack) error {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	if a.expirePriorityQueue.Len() == 0 {
+		return nil
+	}
+	currTime := time.Now()
+	for a.expirePriorityQueue.Len() > 0 {
+		topItem := a.expirePriorityQueue.Peek()
+		if topItem.activeExpireTime.After(currTime) && topItem.inactiveExpireTime.After(currTime) {
+			// We do not have to check other items anymore.
+			break
+		}
+		// Pop the record item from the priority queue
+		pqItem := heap.Pop(&a.expirePriorityQueue).(*ItemToExpire)
+		if !pqItem.flowRecord.ReadyToSend {
+			// Reset the timeouts and add the record to priority queue.
+			// Delete the record after max retries.
+			pqItem.flowRecord.waitForReadyToSendRetries = pqItem.flowRecord.waitForReadyToSendRetries + 1
+			if pqItem.flowRecord.waitForReadyToSendRetries > MaxRetries {
+				klog.V(2).Infof("Deleting the record after waiting for ready to send with key: %v record: %v", pqItem.flowKey, pqItem.flowRecord)
+				if err := a.deleteFlowKeyFromMapWithoutLock(*pqItem.flowKey); err != nil {
+					return fmt.Errorf("error while deleting flow record after max retries: %v", err)
+				}
+			} else {
+				pqItem.activeExpireTime = currTime.Add(a.activeExpiryTimeout)
+				pqItem.inactiveExpireTime = currTime.Add(a.inactiveExpiryTimeout)
+				heap.Push(&a.expirePriorityQueue, pqItem)
+			}
+			continue
+		}
+		err := callback(*pqItem.flowKey, *pqItem.flowRecord)
+		if err != nil {
+			return fmt.Errorf("callback execution failed for popped flow record with key: %v, record: %v, error: %v", pqItem.flowKey, pqItem.flowRecord, err)
+		}
+		// Delete the flow record if it is expired because of inactive expiry timeout.
+		if pqItem.inactiveExpireTime.Before(currTime) {
+			if err = a.deleteFlowKeyFromMapWithoutLock(*pqItem.flowKey); err != nil {
+				return fmt.Errorf("error while deleting flow record after inactive expiry: %v", err)
+			}
+			continue
+		}
+		// Reset the expireTime for the popped item and push it to the priority queue.
+		if pqItem.activeExpireTime.Before(currTime) {
+			// Reset the active expire timeout and push the record into priority
+			// queue.
+			pqItem.activeExpireTime = currTime.Add(a.activeExpiryTimeout)
+			heap.Push(&a.expirePriorityQueue, pqItem)
+		}
+	}
 	return nil
 }
 
@@ -184,6 +275,7 @@ func (a *AggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record ent
 
 	correlationRequired := isCorrelationRequired(record)
 
+	currTime := time.Now()
 	aggregationRecord, exist := a.flowKeyRecordMap[*flowKey]
 	if exist {
 		if correlationRequired {
@@ -211,6 +303,10 @@ func (a *AggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record ent
 				return err
 			}
 		}
+		// Reset the inactive expiry time in the queue item with updated aggregate
+		// record.
+		a.expirePriorityQueue.Update(aggregationRecord.PriorityQueueItem,
+			flowKey, &aggregationRecord, aggregationRecord.PriorityQueueItem.activeExpireTime, currTime.Add(a.inactiveExpiryTimeout))
 	} else {
 		// Add all the new stat fields and initialize them.
 		if correlationRequired {
@@ -229,15 +325,24 @@ func (a *AggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record ent
 			}
 		}
 		aggregationRecord = AggregationFlowRecord{
-			record,
-			false,
-			true,
+			Record:                    record,
+			ReadyToSend:               false,
+			waitForReadyToSendRetries: 0,
 		}
 		if !correlationRequired {
 			aggregationRecord.ReadyToSend = true
 		}
-	}
+		// Push the record to the priority queue.
+		pqItem := &ItemToExpire{
+			flowKey: flowKey,
+		}
+		aggregationRecord.PriorityQueueItem = pqItem
 
+		pqItem.flowRecord = &aggregationRecord
+		pqItem.activeExpireTime = currTime.Add(a.activeExpiryTimeout)
+		pqItem.inactiveExpireTime = currTime.Add(a.inactiveExpiryTimeout)
+		heap.Push(&a.expirePriorityQueue, pqItem)
+	}
 	a.flowKeyRecordMap[*flowKey] = aggregationRecord
 	return nil
 }
@@ -390,6 +495,33 @@ func (a *AggregationProcess) aggregateRecords(incomingRecord, existingRecord ent
 	return nil
 }
 
+// ResetStatElementsInRecord is called by the user after the aggregation record
+// is sent after its expiry either by active or inactive expiry interval. This should
+// be called by user after acquiring the mutex in the Aggregation process.
+func (a *AggregationProcess) ResetStatElementsInRecord(record entities.Record) error {
+	statsElementList := a.aggregateElements.StatsElements
+	antreaSourceStatsElements := a.aggregateElements.AggregatedSourceStatsElements
+	antreaDestinationStatsElements := a.aggregateElements.AggregatedDestinationStatsElements
+	for i, element := range statsElementList {
+		if ieWithValue, exist := record.GetInfoElementWithValue(element); exist {
+			ieWithValue.Value = uint64(0)
+		} else {
+			return fmt.Errorf("element with name %v in statsElements is not present in the record", element)
+		}
+		if ieWithValue, exist := record.GetInfoElementWithValue(antreaSourceStatsElements[i]); exist {
+			ieWithValue.Value = uint64(0)
+		} else {
+			return fmt.Errorf("element with name %v in statsElements is not present in the record", antreaSourceStatsElements[i])
+		}
+		if ieWithValue, exist := record.GetInfoElementWithValue(antreaDestinationStatsElements[i]); exist {
+			ieWithValue.Value = uint64(0)
+		} else {
+			return fmt.Errorf("element with name %v in statsElements is not present in the record", antreaDestinationStatsElements[i])
+		}
+	}
+	return nil
+}
+
 func (a *AggregationProcess) addFieldsForStatsAggregation(record entities.Record, fillSrcStats, fillDstStats bool) error {
 	if a.aggregateElements == nil {
 		return nil
@@ -400,8 +532,6 @@ func (a *AggregationProcess) addFieldsForStatsAggregation(record entities.Record
 	antreaElements := append(antreaSourceStatsElements, antreaDestinationStatsElements...)
 
 	for _, element := range antreaElements {
-		// Get the new info element from Antrea registry.
-		// TODO: Take antrea registry enterpriseID as input to make this generic.
 		ie, err := registry.GetInfoElement(element, registry.AntreaEnterpriseID)
 		if err != nil {
 			return err

--- a/pkg/intermediate/priorityqueue.go
+++ b/pkg/intermediate/priorityqueue.go
@@ -1,0 +1,84 @@
+// Copyright 2021 VMware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intermediate
+
+import (
+	"container/heap"
+	"time"
+)
+
+type ItemToExpire struct {
+	// Flow related info
+	flowKey            *FlowKey
+	flowRecord         *AggregationFlowRecord
+	activeExpireTime   time.Time
+	inactiveExpireTime time.Time
+	// Index in the priority queue (heap)
+	index int
+}
+
+type TimeToExpirePriorityQueue []*ItemToExpire
+
+func (pq TimeToExpirePriorityQueue) Len() int {
+	return len(pq)
+}
+
+func (pq TimeToExpirePriorityQueue) minExpireTime(i int) time.Time {
+	if pq[i].activeExpireTime.Before(pq[i].inactiveExpireTime) {
+		return pq[i].activeExpireTime
+	} else {
+		return pq[i].inactiveExpireTime
+	}
+}
+
+func (pq TimeToExpirePriorityQueue) Less(i, j int) bool {
+	return pq.minExpireTime(i).Before(pq.minExpireTime(j))
+}
+
+func (pq TimeToExpirePriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *TimeToExpirePriorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*ItemToExpire)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *TimeToExpirePriorityQueue) Pop() interface{} {
+	n := len(*pq)
+	item := (*pq)[n-1]
+	item.index = -1
+	*pq = (*pq)[0:(n - 1)]
+	return item
+}
+
+// Peek returns the item at the beginning of the queue, without removing the
+// item or otherwise mutating the queue. It is safe to call directly.
+func (pq TimeToExpirePriorityQueue) Peek() *ItemToExpire {
+	return pq[0]
+}
+
+// update modifies the priority and flow record of an Item in the queue.
+func (pq *TimeToExpirePriorityQueue) Update(item *ItemToExpire, flowKey *FlowKey, flowRecord *AggregationFlowRecord, activeExpireTime time.Time, inactiveExpireTime time.Time) {
+	item.flowKey = flowKey
+	item.flowRecord = flowRecord
+	item.activeExpireTime = activeExpireTime
+	item.inactiveExpireTime = inactiveExpireTime
+	heap.Fix(pq, item.index)
+}

--- a/pkg/intermediate/priorityqueue_test.go
+++ b/pkg/intermediate/priorityqueue_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 VMware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intermediate
+
+import (
+	"container/heap"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeFlowKey(srcIP, dstIP string, srcPort, dstPort uint16, proto uint8) FlowKey {
+	return FlowKey{
+		SourceAddress:      srcIP,
+		DestinationAddress: dstIP,
+		Protocol:           proto,
+		SourcePort:         srcPort,
+		DestinationPort:    dstPort,
+	}
+}
+func TestTimeToExpirePriorityQueue(t *testing.T) {
+	testFlowsMap := []FlowKey{
+		makeFlowKey("10.0.0.1", "10.0.0.2", 13001, 8080, 6),
+		makeFlowKey("10.0.0.3", "10.0.0.4", 14001, 80, 6),
+		makeFlowKey("10.0.0.1", "10.0.0.2", 1300, 8181, 17),
+		makeFlowKey("10.0.0.2", "10.0.0.3", 1001, 8888, 17),
+	}
+	startTime := time.Now()
+	testFlowsWithExpire := map[FlowKey][]time.Time{
+		testFlowsMap[0]: {startTime.Add(4 * time.Second), startTime.Add(6 * time.Second)},
+		testFlowsMap[1]: {startTime.Add(10 * time.Second), startTime.Add(12 * time.Second)},
+		testFlowsMap[2]: {startTime.Add(1 * time.Second), startTime.Add(3 * time.Second)},
+	}
+	testPriorityQueue := make(TimeToExpirePriorityQueue, 0)
+	i := 0
+	for key, value := range testFlowsWithExpire {
+		item := &ItemToExpire{
+			flowKey:            &key,
+			activeExpireTime:   value[0],
+			inactiveExpireTime: value[1],
+			index:              i,
+		}
+		testPriorityQueue = append(testPriorityQueue, item)
+		i++
+	}
+	heap.Init(&testPriorityQueue)
+	// Add new flow to the priority queue
+	testFlowsWithExpire[testFlowsMap[3]] = []time.Time{startTime.Add(3 * time.Second), startTime.Add(500 * time.Millisecond)}
+	newFlowItem := &ItemToExpire{
+		flowKey:            &testFlowsMap[3],
+		activeExpireTime:   startTime.Add(3 * time.Second),
+		inactiveExpireTime: startTime.Add(500 * time.Millisecond),
+	}
+	heap.Push(&testPriorityQueue, newFlowItem)
+	// Test the Peek() function
+	flowReadyToExpire := testPriorityQueue.Peek()
+	assert.Equalf(t, testFlowsWithExpire[testFlowsMap[3]][0], flowReadyToExpire.activeExpireTime, "Peek() method returns wrong value")
+	assert.Equalf(t, testFlowsWithExpire[testFlowsMap[3]][1], flowReadyToExpire.inactiveExpireTime, "Peek() method returns wrong value")
+	// Test the Update function
+	testPriorityQueue.Update(newFlowItem, &testFlowsMap[3], &AggregationFlowRecord{}, startTime.Add(2*time.Second), startTime.Add(4*time.Second))
+	testFlowsWithExpire[testFlowsMap[3]] = []time.Time{startTime.Add(2 * time.Second), startTime.Add(4 * time.Second)}
+	assert.Equalf(t, testFlowsWithExpire[testFlowsMap[3]][0], newFlowItem.activeExpireTime, "Update method doesn't work")
+	assert.Equalf(t, testFlowsWithExpire[testFlowsMap[3]][1], newFlowItem.inactiveExpireTime, "Update method doesn't work")
+	// Test the Pop function
+	for testPriorityQueue.Len() > 0 {
+		queueLen := testPriorityQueue.Len()
+		item := heap.Pop(&testPriorityQueue).(*ItemToExpire)
+		switch queueLen {
+		case 1:
+			assert.Equal(t, testFlowsWithExpire[testFlowsMap[1]][0], item.activeExpireTime)
+			assert.Equal(t, testFlowsWithExpire[testFlowsMap[1]][1], item.inactiveExpireTime)
+		case 2:
+			assert.Equal(t, testFlowsWithExpire[testFlowsMap[0]][0], item.activeExpireTime)
+			assert.Equal(t, testFlowsWithExpire[testFlowsMap[0]][1], item.inactiveExpireTime)
+		case 3:
+			assert.Equal(t, testFlowsWithExpire[testFlowsMap[3]][0], item.activeExpireTime)
+			assert.Equal(t, testFlowsWithExpire[testFlowsMap[3]][1], item.inactiveExpireTime)
+		case 4:
+			assert.Equal(t, testFlowsWithExpire[testFlowsMap[2]][0], item.activeExpireTime)
+			assert.Equal(t, testFlowsWithExpire[testFlowsMap[2]][1], item.inactiveExpireTime)
+		default:
+			t.Fatalf("queue length %v is not valid value", queueLen)
+		}
+	}
+}

--- a/pkg/intermediate/types.go
+++ b/pkg/intermediate/types.go
@@ -26,14 +26,13 @@ type FlowKey struct {
 
 type AggregationFlowRecord struct {
 	Record entities.Record
+	// Flow record contains mapping to its reference in priority queue.
+	PriorityQueueItem *ItemToExpire
 	// ReadyToSend is an indicator that we received all required records for the
 	// given flow, i.e., records from source and destination nodes for the case
 	// inter-node flow and record from the node for the case of intra-node flow.
-	ReadyToSend bool
-	// IsActive is a flag that indicates whether the flow is active or not. If
-	// aggregation process stop receiving flows from collector process, we deem
-	// the flow as inactive.
-	IsActive bool
+	ReadyToSend               bool
+	waitForReadyToSendRetries int
 }
 
 type AggregationElements struct {


### PR DESCRIPTION
Aggregation proccess is modified to maintain records in a heap-based on active and inactive expiry
timeouts provided as inputs.
This is needed for providing granular intervals when exporting flow records through flow aggregator in Antrea: https://github.com/vmware-tanzu/antrea/pull/1949

Priority queue code is maintained in a separate package. This can be reused in Antrea flow exporter.