### PR TITLE
Add support for isMetadataFilled for aggregation process

### DIFF
--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -729,6 +729,7 @@ func TestDeleteFlowKeyFromMapWithLock(t *testing.T) {
 		&ItemToExpire{},
 		true,
 		0,
+		false,
 	}
 	aggregationProcess.flowKeyRecordMap[flowKey1] = aggFlowRecord
 	assert.Equal(t, 1, len(aggregationProcess.flowKeyRecordMap))
@@ -913,6 +914,7 @@ func runCorrelationAndCheckResult(t *testing.T, ap *AggregationProcess, record1,
 	assert.Equal(t, oldActiveExpiryTime, item.activeExpireTime)
 	if !isIntraNode && needsCorrleation {
 		assert.NotEqual(t, oldInactiveExpiryTime, item.inactiveExpireTime)
+		assert.True(t, ap.IsMetadataFilled(aggRecord))
 	}
 	if !isIntraNode && !needsCorrleation {
 		// for inter-Node deny connections, either src or dst Pod info will be resolved.
@@ -922,6 +924,7 @@ func runCorrelationAndCheckResult(t *testing.T, ap *AggregationProcess, record1,
 		egress, _ := aggRecord.Record.GetInfoElementWithValue("egressNetworkPolicyRuleAction")
 		ingress, _ := aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRuleAction")
 		assert.True(t, egress.Value != 0 || ingress.Value != 0)
+		assert.False(t, ap.IsMetadataFilled(aggRecord))
 	} else {
 		ieWithValue, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
 		assert.Equal(t, "pod1", ieWithValue.Value)
@@ -938,6 +941,7 @@ func runCorrelationAndCheckResult(t *testing.T, ap *AggregationProcess, record1,
 		assert.Equal(t, uint16(4739), ieWithValue.Value)
 		ingressPriority, _ := aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRulePriority")
 		assert.Equal(t, ingressPriority.Value, int32(50000))
+		assert.True(t, ap.IsMetadataFilled(aggRecord))
 	}
 }
 

--- a/pkg/intermediate/types.go
+++ b/pkg/intermediate/types.go
@@ -33,6 +33,11 @@ type AggregationFlowRecord struct {
 	// inter-node flow and record from the node for the case of intra-node flow.
 	ReadyToSend               bool
 	waitForReadyToSendRetries int
+	// isMetaDataFilled is an indicator for IPFIX Mediator to check whether K8s
+	// metadata are filled for flow record. It is always true for Intra-Node
+	// and ToExternal flows and only applicable for Inter-Node flows that are
+	// not required to be correlated. (e.g. flows with Egress deny rule applied)
+	isMetaDataFilled bool
 }
 
 type AggregationElements struct {


### PR DESCRIPTION
If correlation is required, we will set `isMetadataFilled` to true.
if correlation is not required, we will set `isMetadataFilled` to true only when the flow is intra-Node.

`isMetadataFilled` is always true for Intra-Node and ToExternal flows and only applicable for Inter-Node flows that are not required to be correlated. (e.g. flows with Egress deny rule applied)