### PR TITLE
Remove element map from record

### DIFF
--- a/pkg/entities/record_test.go
+++ b/pkg/entities/record_test.go
@@ -30,8 +30,8 @@ func TestPrepareRecord(t *testing.T) {
 		expectLen uint16
 		expectErr error
 	}{
-		{NewDataRecord(uniqueTemplateID, 1), 0, nil},
-		{NewTemplateRecord(uniqueTemplateID, 1), 4, nil},
+		{NewDataRecord(uniqueTemplateID, 1, false), 0, nil},
+		{NewTemplateRecord(uniqueTemplateID, 1, false), 4, nil},
 	}
 
 	for _, test := range prepareRecordTests {
@@ -80,8 +80,8 @@ func TestAddInfoElements(t *testing.T) {
 		ieList  []*InfoElement
 		valList []interface{}
 	}{
-		{NewTemplateRecord(uniqueTemplateID, 1), testIEs, nil},
-		{NewDataRecord(uniqueTemplateID, len(testIEs)), testIEs, valData},
+		{NewTemplateRecord(uniqueTemplateID, 12, false), testIEs, nil},
+		{NewDataRecord(uniqueTemplateID, len(testIEs), false), testIEs, valData},
 	}
 
 	for i, test := range addIETests {
@@ -90,11 +90,11 @@ func TestAddInfoElements(t *testing.T) {
 			if i == 0 {
 				// For template record
 				ie := NewInfoElementWithValue(testIE, nil)
-				actualErr = test.record.AddInfoElement(ie, false)
+				actualErr = test.record.AddInfoElement(ie)
 			} else {
 				// For data record
 				ie := NewInfoElementWithValue(testIE, test.valList[j])
-				actualErr = test.record.AddInfoElement(ie, false)
+				actualErr = test.record.AddInfoElement(ie)
 				if testIE.Len == VariableLength {
 					_, ok := test.valList[j].(string)
 					if !ok {
@@ -114,18 +114,18 @@ func TestAddInfoElements(t *testing.T) {
 }
 
 func TestGetInfoElementWithValue(t *testing.T) {
-	templateRec := NewTemplateRecord(256, 1)
-	templateRec.elementsMap = make(map[string]*InfoElementWithValue)
+	templateRec := NewTemplateRecord(256, 1, true)
+	templateRec.orderedElementList = make([]*InfoElementWithValue, 0)
 	ie := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
-	templateRec.elementsMap["sourceIPv4Address"] = ie
+	templateRec.orderedElementList = append(templateRec.orderedElementList, ie)
 	_, exist := templateRec.GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
 	_, exist = templateRec.GetInfoElementWithValue("destinationIPv4Address")
 	assert.Equal(t, false, exist)
-	dataRec := NewDataRecord(256, 1)
-	dataRec.elementsMap = make(map[string]*InfoElementWithValue)
+	dataRec := NewDataRecord(256, 1, true)
+	dataRec.orderedElementList = make([]*InfoElementWithValue, 0)
 	ie = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
-	dataRec.elementsMap["sourceIPv4Address"] = ie
+	dataRec.orderedElementList = append(dataRec.orderedElementList, ie)
 	infoElementWithValue, _ := dataRec.GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, net.ParseIP("10.0.0.1"), infoElementWithValue.Value)
 	infoElementWithValue, _ = dataRec.GetInfoElementWithValue("destinationIPv4Address")

--- a/pkg/entities/set.go
+++ b/pkg/entities/set.go
@@ -106,9 +106,9 @@ func (s *set) UpdateLenInHeader() {
 func (s *set) AddRecord(elements []*InfoElementWithValue, templateID uint16) error {
 	var record Record
 	if s.setType == Data {
-		record = NewDataRecord(templateID, len(elements))
+		record = NewDataRecord(templateID, len(elements), s.isDecoding)
 	} else if s.setType == Template {
-		record = NewTemplateRecord(templateID, len(elements))
+		record = NewTemplateRecord(templateID, len(elements), s.isDecoding)
 		err := record.PrepareRecord()
 		if err != nil {
 			return err
@@ -118,7 +118,7 @@ func (s *set) AddRecord(elements []*InfoElementWithValue, templateID uint16) err
 	}
 
 	for _, element := range elements {
-		err := record.AddInfoElement(element, s.isDecoding)
+		err := record.AddInfoElement(element)
 		if err != nil {
 			return err
 		}

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -36,10 +36,7 @@ func TestAddRecordIPv4Addresses(t *testing.T) {
 	elements = append(elements, ie1, ie2)
 	err = encodingSet.AddRecord(elements, 256)
 	assert.NoError(t, err)
-	infoElementWithValue, _ := encodingSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
-	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x1}), infoElementWithValue.Value)
-	infoElementWithValue, _ = encodingSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv4Address")
-	assert.Equal(t, net.IP([]byte{0xa, 0x0, 0x0, 0x2}), infoElementWithValue.Value)
+	assert.Equal(t, []byte{0xa, 0x0, 0x0, 0x1, 0xa, 0x0, 0x0, 0x2}, encodingSet.GetRecords()[0].GetBuffer())
 }
 
 func TestAddRecordIPv6Addresses(t *testing.T) {
@@ -52,10 +49,7 @@ func TestAddRecordIPv6Addresses(t *testing.T) {
 	err := newSet.PrepareSet(Template, testTemplateID)
 	assert.NoError(t, err)
 	newSet.AddRecord(elements, 256)
-	_, exist := newSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
-	assert.Equal(t, true, exist)
-	_, exist = newSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv6Address")
-	assert.Equal(t, true, exist)
+	assert.Equal(t, []byte{0x1, 0x0, 0x0, 0x2, 0x0, 0x1b, 0x0, 0x10, 0x0, 0x1c, 0x0, 0x10}, newSet.GetRecords()[0].GetBuffer())
 	newSet.ResetSet()
 	// Test with data record
 	err = newSet.PrepareSet(Data, testTemplateID)
@@ -65,10 +59,9 @@ func TestAddRecordIPv6Addresses(t *testing.T) {
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
 	elements = append(elements, ie1, ie2)
 	newSet.AddRecord(elements, 256)
-	infoElementWithValue, _ := newSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
-	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}), infoElementWithValue.Value)
-	infoElementWithValue, _ = newSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv6Address")
-	assert.Equal(t, net.IP([]byte{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfc}), infoElementWithValue.Value)
+	srcIP := []byte(net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
+	dstIP := []byte(net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
+	assert.Equal(t, append(srcIP, dstIP...), newSet.GetRecords()[0].GetBuffer())
 }
 
 func TestGetSetType(t *testing.T) {

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -48,17 +48,17 @@ func (m *MockRecord) EXPECT() *MockRecordMockRecorder {
 }
 
 // AddInfoElement mocks base method
-func (m *MockRecord) AddInfoElement(arg0 *entities.InfoElementWithValue, arg1 bool) error {
+func (m *MockRecord) AddInfoElement(arg0 *entities.InfoElementWithValue) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddInfoElement", arg0, arg1)
+	ret := m.ctrl.Call(m, "AddInfoElement", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddInfoElement indicates an expected call of AddInfoElement
-func (mr *MockRecordMockRecorder) AddInfoElement(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRecordMockRecorder) AddInfoElement(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInfoElement", reflect.TypeOf((*MockRecord)(nil).AddInfoElement), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInfoElement", reflect.TypeOf((*MockRecord)(nil).AddInfoElement), arg0)
 }
 
 // GetBuffer mocks base method

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -488,20 +488,10 @@ func TestAggregationProcess(t *testing.T) {
 }
 
 func TestAddOriginalExporterInfo(t *testing.T) {
-	// Test message with template set
-	message := createMsgwithTemplateSet(false)
+	message := createDataMsgForSrc(t, false, false, false, false, false)
 	err := addOriginalExporterInfo(message)
 	assert.NoError(t, err)
 	record := message.GetSet().GetRecords()[0]
-	_, exist := record.GetInfoElementWithValue("originalExporterIPv4Address")
-	assert.Equal(t, true, exist)
-	_, exist = record.GetInfoElementWithValue("originalObservationDomainId")
-	assert.Equal(t, true, exist)
-	// Test message with data set
-	message = createDataMsgForSrc(t, false, false, false, false, false)
-	err = addOriginalExporterInfo(message)
-	assert.NoError(t, err)
-	record = message.GetSet().GetRecords()[0]
 	ieWithValue, exist := record.GetInfoElementWithValue("originalExporterIPv4Address")
 	assert.Equal(t, true, exist)
 	assert.Equal(t, net.IP{0x7f, 0x0, 0x0, 0x1}, ieWithValue.Value)
@@ -511,20 +501,11 @@ func TestAddOriginalExporterInfo(t *testing.T) {
 }
 
 func TestAddOriginalExporterInfoIPv6(t *testing.T) {
-	// Test message with template set
-	message := createMsgwithTemplateSet(true)
+	// Test message with data set
+	message := createDataMsgForSrc(t, true, false, false, false, false)
 	err := addOriginalExporterInfo(message)
 	assert.NoError(t, err)
 	record := message.GetSet().GetRecords()[0]
-	_, exist := record.GetInfoElementWithValue("originalExporterIPv6Address")
-	assert.Equal(t, true, exist)
-	_, exist = record.GetInfoElementWithValue("originalObservationDomainId")
-	assert.Equal(t, true, exist)
-	// Test message with data set
-	message = createDataMsgForSrc(t, true, false, false, false, false)
-	err = addOriginalExporterInfo(message)
-	assert.NoError(t, err)
-	record = message.GetSet().GetRecords()[0]
 	ieWithValue, exist := record.GetInfoElementWithValue("originalExporterIPv6Address")
 	assert.Equal(t, true, exist)
 	assert.Equal(t, net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1}, ieWithValue.Value)


### PR DESCRIPTION
Use loop through `orderedElementList` for search element in record because in current use case, number of elements is small. We can consider using ordered map ([example](https://github.com/wk8/go-ordered-map)) if number of elements is large in the future (currently it involves more overhead). 
Did not remove `orderedElementList` when for encoding cases because it will be used in intermediate process when more fields will be added to decoded elements.

fixes #201