### PR TITLE
Add more methods to Kafka producer

### DIFF
--- a/pkg/producer/convertor/test/flowtype_test.go
+++ b/pkg/producer/convertor/test/flowtype_test.go
@@ -307,7 +307,7 @@ func TestKafkaProducer_Publish(t *testing.T) {
 				close(messageChan)
 			}()
 
-			kafkaProducer.Publish(messageChan)
+			kafkaProducer.PublishIPFIXMessages(messageChan)
 
 			kafkaMsg1 := <-mockSaramaProducer.Successes()
 			kafkaMsg1InBytes, _ := kafkaMsg1.Value.Encode()

--- a/pkg/producer/kafka_test.go
+++ b/pkg/producer/kafka_test.go
@@ -58,7 +58,8 @@ func doListenerTLSTest(t *testing.T, serverTLSConfig *tls.Config, caCert, client
 	defer closeTmpFile(t, keyFile)
 
 	testInput := ProducerInput{
-		KafkaLogSuccesses:  false,
+		KafkaLogSuccesses:  true,
+		KafkaLogErrors:     true,
 		KafkaCAFile:        caCertFile.Name(),
 		KafkaTLSCertFile:   certFile.Name(),
 		KafkaTLSKeyFile:    keyFile.Name(),
@@ -72,10 +73,9 @@ func doListenerTLSTest(t *testing.T, serverTLSConfig *tls.Config, caCert, client
 	}
 	err = kafkaProducer.InitSaramaProducer()
 	assert.NoError(t, err)
-	if err == nil {
-		err = kafkaProducer.producer.Close()
-		assert.NoError(t, err)
-	}
+	saramaProducer := kafkaProducer.GetSaramaProducer()
+	assert.NotNil(t, saramaProducer)
+	kafkaProducer.Close()
 }
 
 func createTmpFileAndWrite(t *testing.T, content, pattern string) *os.File {

--- a/pkg/test/collector_producer_test.go
+++ b/pkg/test/collector_producer_test.go
@@ -102,7 +102,7 @@ func TestCollectorToProducer(t *testing.T) {
 	go func() {
 		mockSaramaProducer.ExpectInputAndSucceed()
 		mockSaramaProducer.ExpectInputAndSucceed()
-		kafkaProducer.Publish(cp.GetMsgChan())
+		kafkaProducer.PublishIPFIXMessages(cp.GetMsgChan())
 	}()
 
 	kafkaMsg1 := <-mockSaramaProducer.Successes()


### PR DESCRIPTION
Add methods to send the IPFIX record instead of the whole IPFIX
message, close the sarama kafka go client, get the sarama kafka go client etc.