### PR TITLE
Add field AreExternalFieldsFilled for AggregationFlowRecord

### DIFF
--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -273,6 +273,14 @@ func (a *AggregationProcess) AreCorrelatedFieldsFilled(record AggregationFlowRec
 	return record.areCorrelatedFieldsFilled
 }
 
+func (a *AggregationProcess) SetExternalFieldsFilled(record *AggregationFlowRecord, isFilled bool) {
+	record.areExternalFieldsFilled = isFilled
+}
+
+func (a *AggregationProcess) AreExternalFieldsFilled(record AggregationFlowRecord) bool {
+	return record.areExternalFieldsFilled
+}
+
 // addOrUpdateRecordInMap either adds the record to flowKeyMap or updates the record in
 // flowKeyMap by doing correlation or updating the stats.
 func (a *AggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record entities.Record) error {
@@ -346,13 +354,14 @@ func (a *AggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record ent
 			aggregationRecord.ReadyToSend = true
 			// If no correlation is required for an Inter-Node record, K8s metadata is
 			// expected to be not completely filled. For Intra-Node flows and ToExternal
-			// flows, isMetaDataFilled is set to true by default.
+			// flows, areCorrelatedFieldsFilled is set to true by default.
 			if flowType == registry.FlowTypeInterNode {
 				aggregationRecord.areCorrelatedFieldsFilled = false
 			} else {
 				aggregationRecord.areCorrelatedFieldsFilled = true
 			}
 		}
+		aggregationRecord.areExternalFieldsFilled = false
 		// Push the record to the priority queue.
 		pqItem := &ItemToExpire{
 			flowKey: flowKey,

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -677,6 +677,7 @@ func TestDeleteFlowKeyFromMapWithLock(t *testing.T) {
 		true,
 		0,
 		false,
+		false,
 	}
 	aggregationProcess.flowKeyRecordMap[flowKey1] = aggFlowRecord
 	assert.Equal(t, 1, len(aggregationProcess.flowKeyRecordMap))

--- a/pkg/intermediate/types.go
+++ b/pkg/intermediate/types.go
@@ -33,12 +33,18 @@ type AggregationFlowRecord struct {
 	// inter-node flow and record from the node for the case of intra-node flow.
 	ReadyToSend               bool
 	waitForReadyToSendRetries int
-	// areCorrelatedFieldsFilled is an indicator for IPFIX Mediator to check
-	// whether correlated fields are filled for flow record. It is always true
-	// for Intra-Node and ToExternal flows and only applicable for Inter-Node
-	// flows that are not required to be correlated. (e.g. flows with Egress
-	// deny rule applied)
+	// areCorrelatedFieldsFilled is an indicator for IPFIX Mediator to check whether K8s
+	// metadata are filled for flow record. It is always true for Intra-Node
+	// and ToExternal flows and only applicable for Inter-Node flows that are
+	// not required to be correlated. (e.g. flows with Egress deny rule applied)
 	areCorrelatedFieldsFilled bool
+	// Some fields could be filled externally on aggregation records once before
+	// exporting them in IPFIX mediator, e.g., metadata of a flow.
+	// areExternalFieldsFilled is an indicator for IPFIX Mediator to check whether
+	// these fields has been filled or not before exporting. This field is set to
+	// false when creating new AggregationFlowRecord. Setting and utilizing this
+	// field is upto the user and not used in go-ipfix library code.
+	areExternalFieldsFilled bool
 }
 
 type AggregationElements struct {


### PR DESCRIPTION
Some fields like Pod labels will be filled externally on the IPFIX Mediator, areExternalFieldsFilled is an indicator for IPFIX Mediator to check whether these fields has been filled. 
This field is set to false when creating new AggregationFlowRecord.
Setting and utilizing this field is upto the user and not used in go-ipfix library code.