### PR TITLE
Fix field set/get by modifying flowRecordMap struct

### DIFF
--- a/pkg/intermediate/types.go
+++ b/pkg/intermediate/types.go
@@ -33,11 +33,12 @@ type AggregationFlowRecord struct {
 	// inter-node flow and record from the node for the case of intra-node flow.
 	ReadyToSend               bool
 	waitForReadyToSendRetries int
-	// isMetaDataFilled is an indicator for IPFIX Mediator to check whether K8s
-	// metadata are filled for flow record. It is always true for Intra-Node
-	// and ToExternal flows and only applicable for Inter-Node flows that are
-	// not required to be correlated. (e.g. flows with Egress deny rule applied)
-	isMetaDataFilled bool
+	// areCorrelatedFieldsFilled is an indicator for IPFIX Mediator to check
+	// whether correlated fields are filled for flow record. It is always true
+	// for Intra-Node and ToExternal flows and only applicable for Inter-Node
+	// flows that are not required to be correlated. (e.g. flows with Egress
+	// deny rule applied)
+	areCorrelatedFieldsFilled bool
 }
 
 type AggregationElements struct {
@@ -47,4 +48,4 @@ type AggregationElements struct {
 	AggregatedDestinationStatsElements []string
 }
 
-type FlowKeyRecordMapCallBack func(key FlowKey, record AggregationFlowRecord) error
+type FlowKeyRecordMapCallBack func(key FlowKey, record *AggregationFlowRecord) error

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -219,8 +219,8 @@ func testCollectorToIntermediate(t *testing.T, address net.Addr, isIPv6 bool) {
 
 }
 
-func copyFlowKeyRecordMap(key intermediate.FlowKey, aggregationFlowRecord intermediate.AggregationFlowRecord) error {
-	flowKeyRecordMap[key] = aggregationFlowRecord
+func copyFlowKeyRecordMap(key intermediate.FlowKey, aggregationFlowRecord *intermediate.AggregationFlowRecord) error {
+	flowKeyRecordMap[key] = *aggregationFlowRecord
 	return nil
 }
 


### PR DESCRIPTION
`SetMetadataFilled` does not take effect on `AggregationRecord` because we are doing it on copy instead of directly onto the record. Modifying value type in `flowRecordMap` will fix this issue.
It was not detected before because usually one deny record for a connection will be exported in our testing settings, which does not involve update for same record.

Also changed `isMetadataFilled` and related function name to `areCorrelatedFieldsFilled` to be more accurate.