### PR TITLE
Better buffer management in Collection process

### DIFF
--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -358,11 +358,10 @@ func (cp *CollectingProcess) updateAddress(address net.Addr) {
 
 // getMessageLength returns buffer length by decoding the header
 func getMessageLength(msgBuffer *bytes.Buffer) (int, error) {
-	var version, msgLen, setID, setLen uint16
-	var exportTime, sequencNum, obsDomainID uint32
+	var version, msgLen uint16
 	// We do not really need to decode whole header. Support an utility function
 	// that decodes header based on the offset.
-	err := util.Decode(msgBuffer, binary.BigEndian, &version, &msgLen, &exportTime, &sequencNum, &obsDomainID, &setID, &setLen)
+	err := util.Decode(msgBuffer, binary.BigEndian, &version, &msgLen)
 	if err != nil {
 		return 0, fmt.Errorf("cannot decode message: %v", err)
 	}
@@ -372,14 +371,12 @@ func getMessageLength(msgBuffer *bytes.Buffer) (int, error) {
 // getFieldLength returns string field length for data record
 // (encoding reference: https://tools.ietf.org/html/rfc7011#appendix-A.5)
 func getFieldLength(dataBuffer *bytes.Buffer) int {
-	lengthBuff := dataBuffer.Next(1)
 	var lengthOneByte uint8
-	util.Decode(bytes.NewBuffer(lengthBuff), binary.BigEndian, &lengthOneByte)
+	util.Decode(dataBuffer, binary.BigEndian, &lengthOneByte)
 	if lengthOneByte < 255 { // string length is less than 255
 		return int(lengthOneByte)
 	}
 	var lengthTwoBytes uint16
-	lengthBuff = dataBuffer.Next(2)
-	util.Decode(bytes.NewBuffer(lengthBuff), binary.BigEndian, &lengthTwoBytes)
+	util.Decode(dataBuffer, binary.BigEndian, &lengthTwoBytes)
 	return int(lengthTwoBytes)
 }

--- a/pkg/collector/udp.go
+++ b/pkg/collector/udp.go
@@ -65,8 +65,8 @@ func (cp *CollectingProcess) startUDPServer() {
 		}
 		defer conn.Close()
 		go func() {
+			buff := make([]byte, cp.maxBufferSize)
 			for {
-				buff := make([]byte, cp.maxBufferSize)
 				size, err := conn.Read(buff)
 				if err != nil {
 					if size == 0 { // received stop collector message
@@ -82,7 +82,9 @@ func (cp *CollectingProcess) startUDPServer() {
 				}
 				klog.V(2).Infof("Receiving %d bytes from %s", size, address.String())
 				cp.handleUDPClient(address, &wg)
-				cp.clients[address.String()].packetChan <- bytes.NewBuffer(buff[0:size])
+				buffBytes := make([]byte, size)
+				copy(buffBytes, buff[0:size])
+				cp.clients[address.String()].packetChan <- bytes.NewBuffer(buffBytes)
 			}
 		}()
 	} else { // use udp

--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -567,9 +567,21 @@ func (a *AggregationProcess) addFieldsForStatsAggregation(record entities.Record
 	statsElementList := a.aggregateElements.StatsElements
 	antreaSourceStatsElements := a.aggregateElements.AggregatedSourceStatsElements
 	antreaDestinationStatsElements := a.aggregateElements.AggregatedDestinationStatsElements
-	antreaElements := append(antreaSourceStatsElements, antreaDestinationStatsElements...)
 
-	for _, element := range antreaElements {
+	for _, element := range antreaSourceStatsElements {
+		ie, err := registry.GetInfoElement(element, registry.AntreaEnterpriseID)
+		if err != nil {
+			return err
+		}
+		buffBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(buffBytes, uint64(0))
+		ieWithValue := entities.NewInfoElementWithValue(ie, buffBytes)
+		err = record.AddInfoElement(ieWithValue)
+		if err != nil {
+			return err
+		}
+	}
+	for _, element := range antreaDestinationStatsElements {
 		ie, err := registry.GetInfoElement(element, registry.AntreaEnterpriseID)
 		if err != nil {
 			return err


### PR DESCRIPTION
With these fixes, we see better memory consumption in Antrea
benchmark tests.

Before fix:
```
vagrant@k8s-node-worker-1:~/antrea/pkg/flowaggregator$ go test -test.v -run=none -test.benchmem  -bench=. -memprofile memprofile.out -cpuprofile profile.out
goos: linux
goarch: amd64
pkg: antrea.io/antrea/pkg/flowaggregator
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkIntraNodeFlowRecords
    flowaggregator_perf_test.go:446: Num messages received: 1549326
BenchmarkIntraNodeFlowRecords-2           1 120009611181 ns/op 11037419792 B/op 325437079 allocs/op
PASS
ok   antrea.io/antrea/pkg/flowaggregator 120.337s
```
After fix:

```
vagrant@k8s-node-worker-1:~/antrea/pkg/flowaggregator$ go test -test.v -run=none -test.benchmem  -bench=. -memprofile memprofile.out -cpuprofile profile.out
goos: linux
goarch: amd64
pkg: antrea.io/antrea/pkg/flowaggregator
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkIntraNodeFlowRecords
    flowaggregator_perf_test.go:468: Num messages received: 1540913
BenchmarkIntraNodeFlowRecords-2   	       1	120003846594 ns/op	8858260264 B/op	333422689 allocs/op
PASS
```