### PR TITLE
Add more metadata to aggregated flow record

### DIFF
--- a/pkg/intermediate/types.go
+++ b/pkg/intermediate/types.go
@@ -45,6 +45,12 @@ type AggregationFlowRecord struct {
 	// false when creating new AggregationFlowRecord. Setting and utilizing this
 	// field is upto the user and not used in go-ipfix library code.
 	areExternalFieldsFilled bool
+	// isIPv4 indicates whether the source and destination addresses are IPv4 or
+	// IPv6 in the aggregated flow record.
+	isIPv4 bool
+	// isExporterIPv4 indicates whether the exporter address of the received flow
+	// aggregator is IPv4 or IPv6.
+	isExporterIPv4 bool
 }
 
 type AggregationElements struct {


### PR DESCRIPTION
Add isIPv4 and isExporterIPv4 fields to aggregated flow record.

This is related to [the issue](https://github.com/antrea-io/antrea/issues/2282) raised in Antrea dual-stack cluster tests.