### PR TITLE
Avoid sending duplicate records at aggregator

### DIFF
--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -254,9 +254,10 @@ func (a *AggregationProcess) ForAllExpiredFlowRecordsDo(callback FlowKeyRecordMa
 		}
 		// Reset the expireTime for the popped item and push it to the priority queue.
 		if pqItem.activeExpireTime.Before(currTime) {
-			// Reset the active expire timeout and push the record into priority
-			// queue.
+			// Reset the active and inactive expire timeout and push the record into
+			// priority queue.
 			pqItem.activeExpireTime = currTime.Add(a.activeExpiryTimeout)
+			pqItem.inactiveExpireTime = currTime.Add(a.inactiveExpiryTimeout)
 			heap.Push(&a.expirePriorityQueue, pqItem)
 		}
 	}


### PR DESCRIPTION
There are chances that current implementation will send duplicate records at the same time when time is the least common multiple of active timeout and inactive timeout. This will cause throughput calculation at Logstash to have divided by 0 issue. Also it can avoid sending duplicate records at both active & inactive timeout.