### PR TITLE
Collector and Intermediate process performance fix

### DIFF
--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -44,7 +44,7 @@ const (
 	hostPortIPv6 = "[::1]:0"
 )
 
-var elementsWithValueIPv4 = []*entities.InfoElementWithValue{
+var elementsWithValueIPv4 = []entities.InfoElementWithValue{
 	{Element: &entities.InfoElement{Name: "sourceIPv4Address", ElementId: 8, DataType: 18, EnterpriseId: 0, Len: 4}, Value: nil},
 	{Element: &entities.InfoElement{Name: "destinationIPv4Address", ElementId: 12, DataType: 18, EnterpriseId: 0, Len: 4}, Value: nil},
 	{Element: &entities.InfoElement{Name: "destinationNodeName", ElementId: 105, DataType: 13, EnterpriseId: 55829, Len: 65535}, Value: nil},
@@ -262,7 +262,7 @@ func TestCollectingProcess_DecodeTemplateRecord(t *testing.T) {
 
 	templateSet := message.GetSet()
 	assert.NotNil(t, templateSet, "Template record should be stored in message flowset")
-	sourceIPv4Address, exist := templateSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
+	sourceIPv4Address, _, exist := templateSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
 	assert.Equal(t, uint32(0), sourceIPv4Address.Element.EnterpriseId, "Template record is not stored correctly.")
 	// Invalid version
@@ -306,7 +306,7 @@ func TestCollectingProcess_DecodeDataRecord(t *testing.T) {
 	set := message.GetSet()
 	assert.NotNil(t, set, "Data set should be stored in message set")
 	ipAddress := net.IP([]byte{1, 2, 3, 4})
-	sourceIPv4Address, exist := set.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
+	sourceIPv4Address, _, exist := set.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
 	assert.Equal(t, ipAddress, sourceIPv4Address.Value, "sourceIPv4Address should be decoded and stored correctly.")
 	// Malformed data record
@@ -464,7 +464,7 @@ func TestTCPCollectingProcessIPv6(t *testing.T) {
 	cp.Stop()
 	template, _ := cp.getTemplate(1, 256)
 	assert.NotNil(t, template)
-	ie, exist := message.GetSet().GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
+	ie, _, exist := message.GetSet().GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
 	assert.True(t, exist)
 	assert.Equal(t, net.ParseIP("2001:0:3238:DFE1:63::FEFB"), ie.Value)
 }
@@ -493,7 +493,7 @@ func TestUDPCollectingProcessIPv6(t *testing.T) {
 	cp.Stop()
 	template, _ := cp.getTemplate(1, 256)
 	assert.NotNil(t, template)
-	ie, exist := message.GetSet().GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
+	ie, _, exist := message.GetSet().GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
 	assert.True(t, exist)
 	assert.Equal(t, net.ParseIP("2001:0:3238:DFE1:63::FEFB"), ie.Value)
 }

--- a/pkg/entities/ie.go
+++ b/pkg/entities/ie.go
@@ -110,8 +110,8 @@ func NewInfoElement(name string, ieID uint16, ieType IEDataType, entID uint32, l
 	}
 }
 
-func NewInfoElementWithValue(element *InfoElement, value interface{}) *InfoElementWithValue {
-	return &InfoElementWithValue{
+func NewInfoElementWithValue(element *InfoElement, value interface{}) InfoElementWithValue {
+	return InfoElementWithValue{
 		element, value, 0,
 	}
 }

--- a/pkg/entities/record_test.go
+++ b/pkg/entities/record_test.go
@@ -30,7 +30,7 @@ func TestPrepareRecord(t *testing.T) {
 		expectLen uint16
 		expectErr error
 	}{
-		{NewDataRecord(uniqueTemplateID, 1, false), 0, nil},
+		{NewDataRecord(uniqueTemplateID, 1, 0, false), 0, nil},
 		{NewTemplateRecord(uniqueTemplateID, 1, false), 4, nil},
 	}
 
@@ -81,7 +81,7 @@ func TestAddInfoElements(t *testing.T) {
 		valList []interface{}
 	}{
 		{NewTemplateRecord(uniqueTemplateID, 12, false), testIEs, nil},
-		{NewDataRecord(uniqueTemplateID, len(testIEs), false), testIEs, valData},
+		{NewDataRecord(uniqueTemplateID, len(testIEs), 0, false), testIEs, valData},
 	}
 
 	for i, test := range addIETests {
@@ -90,11 +90,11 @@ func TestAddInfoElements(t *testing.T) {
 			if i == 0 {
 				// For template record
 				ie := NewInfoElementWithValue(testIE, nil)
-				actualErr = test.record.AddInfoElement(ie)
+				actualErr = test.record.AddInfoElement(&ie)
 			} else {
 				// For data record
 				ie := NewInfoElementWithValue(testIE, test.valList[j])
-				actualErr = test.record.AddInfoElement(ie)
+				actualErr = test.record.AddInfoElement(&ie)
 				if testIE.Len == VariableLength {
 					_, ok := test.valList[j].(string)
 					if !ok {
@@ -115,19 +115,19 @@ func TestAddInfoElements(t *testing.T) {
 
 func TestGetInfoElementWithValue(t *testing.T) {
 	templateRec := NewTemplateRecord(256, 1, true)
-	templateRec.orderedElementList = make([]*InfoElementWithValue, 0)
+	templateRec.orderedElementList = make([]InfoElementWithValue, 0)
 	ie := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	templateRec.orderedElementList = append(templateRec.orderedElementList, ie)
-	_, exist := templateRec.GetInfoElementWithValue("sourceIPv4Address")
+	_, _, exist := templateRec.GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
-	_, exist = templateRec.GetInfoElementWithValue("destinationIPv4Address")
+	_, _, exist = templateRec.GetInfoElementWithValue("destinationIPv4Address")
 	assert.Equal(t, false, exist)
-	dataRec := NewDataRecord(256, 1, true)
-	dataRec.orderedElementList = make([]*InfoElementWithValue, 0)
+	dataRec := NewDataRecord(256, 1, 0, true)
+	dataRec.orderedElementList = make([]InfoElementWithValue, 0)
 	ie = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
 	dataRec.orderedElementList = append(dataRec.orderedElementList, ie)
-	infoElementWithValue, _ := dataRec.GetInfoElementWithValue("sourceIPv4Address")
+	infoElementWithValue, _, _ := dataRec.GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, net.ParseIP("10.0.0.1"), infoElementWithValue.Value)
-	infoElementWithValue, _ = dataRec.GetInfoElementWithValue("destinationIPv4Address")
-	assert.Nil(t, infoElementWithValue)
+	infoElementWithValue, _, _ = dataRec.GetInfoElementWithValue("destinationIPv4Address")
+	assert.Empty(t, infoElementWithValue)
 }

--- a/pkg/entities/set.go
+++ b/pkg/entities/set.go
@@ -47,7 +47,7 @@ type Set interface {
 	GetSetLength() int
 	GetSetType() ContentType
 	UpdateLenInHeader()
-	AddRecord(elements []*InfoElementWithValue, templateID uint16) error
+	AddRecord(elements []InfoElementWithValue, numExtraElements int, templateID uint16) error
 	GetRecords() []Record
 	GetNumberOfRecords() uint32
 }
@@ -120,10 +120,10 @@ func (s *set) UpdateLenInHeader() {
 	}
 }
 
-func (s *set) AddRecord(elements []*InfoElementWithValue, templateID uint16) error {
+func (s *set) AddRecord(elements []InfoElementWithValue, numExtraElements int, templateID uint16) error {
 	var record Record
 	if s.setType == Data {
-		record = NewDataRecord(templateID, len(elements), s.isDecoding)
+		record = NewDataRecord(templateID, len(elements), numExtraElements, s.isDecoding)
 	} else if s.setType == Template {
 		record = NewTemplateRecord(templateID, len(elements), s.isDecoding)
 		err := record.PrepareRecord()
@@ -133,9 +133,8 @@ func (s *set) AddRecord(elements []*InfoElementWithValue, templateID uint16) err
 	} else {
 		return fmt.Errorf("set type is not supported")
 	}
-
-	for _, element := range elements {
-		err := record.AddInfoElement(element)
+	for i := range elements {
+		err := record.AddInfoElement(&elements[i])
 		if err != nil {
 			return err
 		}

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -14,51 +14,51 @@ const (
 
 func TestAddRecordIPv4Addresses(t *testing.T) {
 	// Test with template encodingSet
-	elements := make([]*InfoElementWithValue, 0)
+	elements := make([]InfoElementWithValue, 0)
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
 	encodingSet := NewSet(false)
 	err := encodingSet.PrepareSet(Template, testTemplateID)
 	assert.NoError(t, err)
-	encodingSet.AddRecord(elements, 256)
-	_, exist := encodingSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
+	encodingSet.AddRecord(elements, 0, 256)
+	_, _, exist := encodingSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
-	_, exist = encodingSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv4Address")
+	_, _, exist = encodingSet.GetRecords()[0].GetInfoElementWithValue("destinationIPv4Address")
 	assert.Equal(t, true, exist)
 	encodingSet.ResetSet()
 	// Test with data encodingSet
 	err = encodingSet.PrepareSet(Data, testTemplateID)
 	assert.NoError(t, err)
-	elements = make([]*InfoElementWithValue, 0)
+	elements = make([]InfoElementWithValue, 0)
 	ie1 = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1").To4())
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("10.0.0.2").To4())
 	elements = append(elements, ie1, ie2)
-	err = encodingSet.AddRecord(elements, 256)
+	err = encodingSet.AddRecord(elements, 0, 256)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte{0xa, 0x0, 0x0, 0x1, 0xa, 0x0, 0x0, 0x2}, encodingSet.GetRecords()[0].GetBuffer())
 }
 
 func TestAddRecordIPv6Addresses(t *testing.T) {
 	// Test with template record
-	elements := make([]*InfoElementWithValue, 0)
+	elements := make([]InfoElementWithValue, 0)
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv6Address", 27, 19, 0, 16), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), nil)
 	elements = append(elements, ie1, ie2)
 	newSet := NewSet(false)
 	err := newSet.PrepareSet(Template, testTemplateID)
 	assert.NoError(t, err)
-	newSet.AddRecord(elements, 256)
+	newSet.AddRecord(elements, 0, 256)
 	assert.Equal(t, []byte{0x1, 0x0, 0x0, 0x2, 0x0, 0x1b, 0x0, 0x10, 0x0, 0x1c, 0x0, 0x10}, newSet.GetRecords()[0].GetBuffer())
 	newSet.ResetSet()
 	// Test with data record
 	err = newSet.PrepareSet(Data, testTemplateID)
 	assert.NoError(t, err)
-	elements = make([]*InfoElementWithValue, 0)
+	elements = make([]InfoElementWithValue, 0)
 	ie1 = NewInfoElementWithValue(NewInfoElement("sourceIPv6Address", 27, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
 	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
 	elements = append(elements, ie1, ie2)
-	newSet.AddRecord(elements, 256)
+	newSet.AddRecord(elements, 0, 256)
 	srcIP := []byte(net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
 	dstIP := []byte(net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
 	assert.Equal(t, append(srcIP, dstIP...), newSet.GetRecords()[0].GetBuffer())
@@ -86,31 +86,31 @@ func TestGetHeaderBuffer(t *testing.T) {
 }
 
 func TestGetRecords(t *testing.T) {
-	elements := make([]*InfoElementWithValue, 0)
+	elements := make([]InfoElementWithValue, 0)
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
 	newSet := NewSet(true)
 	err := newSet.PrepareSet(Template, testTemplateID)
 	assert.NoError(t, err)
-	newSet.AddRecord(elements, testTemplateID)
+	newSet.AddRecord(elements, 0, testTemplateID)
 	assert.Equal(t, 2, len(newSet.GetRecords()[0].GetOrderedElementList()))
 }
 
 func TestGetNumberOfRecords(t *testing.T) {
-	elements := make([]*InfoElementWithValue, 0)
+	elements := make([]InfoElementWithValue, 0)
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
 	newSet := NewSet(true)
 	err := newSet.PrepareSet(Template, testTemplateID)
 	assert.NoError(t, err)
-	newSet.AddRecord(elements, testTemplateID)
+	newSet.AddRecord(elements, 0, testTemplateID)
 	assert.Equal(t, uint32(1), newSet.GetNumberOfRecords())
 }
 
 func TestSet_UpdateLenInHeader(t *testing.T) {
-	elements := make([]*InfoElementWithValue, 0)
+	elements := make([]InfoElementWithValue, 0)
 	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
@@ -120,7 +120,7 @@ func TestSet_UpdateLenInHeader(t *testing.T) {
 	setForEncoding := NewSet(false)
 	err = setForEncoding.PrepareSet(Template, testTemplateID)
 	assert.NoError(t, err)
-	setForEncoding.AddRecord(elements, testTemplateID)
+	setForEncoding.AddRecord(elements, 0, testTemplateID)
 	setForDecoding.UpdateLenInHeader()
 	setForEncoding.UpdateLenInHeader()
 	// Nothing should be written in setForDecoding

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -90,12 +90,13 @@ func (mr *MockRecordMockRecorder) GetFieldCount() *gomock.Call {
 }
 
 // GetInfoElementWithValue mocks base method
-func (m *MockRecord) GetInfoElementWithValue(arg0 string) (*entities.InfoElementWithValue, bool) {
+func (m *MockRecord) GetInfoElementWithValue(arg0 string) (*entities.InfoElementWithValue, int, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInfoElementWithValue", arg0)
 	ret0, _ := ret[0].(*entities.InfoElementWithValue)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
 }
 
 // GetInfoElementWithValue indicates an expected call of GetInfoElementWithValue
@@ -119,10 +120,10 @@ func (mr *MockRecordMockRecorder) GetMinDataRecordLen() *gomock.Call {
 }
 
 // GetOrderedElementList mocks base method
-func (m *MockRecord) GetOrderedElementList() []*entities.InfoElementWithValue {
+func (m *MockRecord) GetOrderedElementList() []entities.InfoElementWithValue {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrderedElementList")
-	ret0, _ := ret[0].([]*entities.InfoElementWithValue)
+	ret0, _ := ret[0].([]entities.InfoElementWithValue)
 	return ret0
 }
 
@@ -172,4 +173,18 @@ func (m *MockRecord) PrepareRecord() error {
 func (mr *MockRecordMockRecorder) PrepareRecord() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareRecord", reflect.TypeOf((*MockRecord)(nil).PrepareRecord))
+}
+
+// SetInfoElementWithValue mocks base method
+func (m *MockRecord) SetInfoElementWithValue(arg0 int, arg1 entities.InfoElementWithValue) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInfoElementWithValue", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetInfoElementWithValue indicates an expected call of SetInfoElementWithValue
+func (mr *MockRecordMockRecorder) SetInfoElementWithValue(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInfoElementWithValue", reflect.TypeOf((*MockRecord)(nil).SetInfoElementWithValue), arg0, arg1)
 }

--- a/pkg/entities/testing/mock_set.go
+++ b/pkg/entities/testing/mock_set.go
@@ -48,17 +48,17 @@ func (m *MockSet) EXPECT() *MockSetMockRecorder {
 }
 
 // AddRecord mocks base method
-func (m *MockSet) AddRecord(arg0 []*entities.InfoElementWithValue, arg1 uint16) error {
+func (m *MockSet) AddRecord(arg0 []entities.InfoElementWithValue, arg1 int, arg2 uint16) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddRecord", arg0, arg1)
+	ret := m.ctrl.Call(m, "AddRecord", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddRecord indicates an expected call of AddRecord
-func (mr *MockSetMockRecorder) AddRecord(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSetMockRecorder) AddRecord(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRecord", reflect.TypeOf((*MockSet)(nil).AddRecord), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRecord", reflect.TypeOf((*MockSet)(nil).AddRecord), arg0, arg1, arg2)
 }
 
 // GetHeaderBuffer mocks base method

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -357,7 +357,7 @@ func (ep *ExportingProcess) createAndSendJSONMsg(set entities.Set) (int, error) 
 	return bytesSent, nil
 }
 
-func (ep *ExportingProcess) updateTemplate(id uint16, elements []*entities.InfoElementWithValue, minDataRecLen uint16) {
+func (ep *ExportingProcess) updateTemplate(id uint16, elements []entities.InfoElementWithValue, minDataRecLen uint16) {
 	ep.templateMutex.Lock()
 	defer ep.templateMutex.Unlock()
 
@@ -379,7 +379,7 @@ func (ep *ExportingProcess) deleteTemplate(id uint16) error {
 	defer ep.templateMutex.Unlock()
 
 	if _, exist := ep.templatesMap[id]; !exist {
-		return fmt.Errorf("process: template %d does not exist in exporting process", id)
+		return fmt.Errorf("template %d does not exist in exporting process", id)
 	}
 	delete(ep.templatesMap, id)
 	return nil
@@ -395,11 +395,11 @@ func (ep *ExportingProcess) sendRefreshedTemplates() error {
 		if err := tempSet.PrepareSet(entities.Template, templateID); err != nil {
 			return err
 		}
-		elements := make([]*entities.InfoElementWithValue, len(tempValue.elements))
+		elements := make([]entities.InfoElementWithValue, len(tempValue.elements))
 		for i, element := range tempValue.elements {
 			elements[i] = entities.NewInfoElementWithValue(element, nil)
 		}
-		err := tempSet.AddRecord(elements, templateID)
+		err := tempSet.AddRecord(elements, 0, templateID)
 		if err != nil {
 			return err
 		}

--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -80,7 +80,7 @@ func TestExportingProcess_SendingTemplateRecordToLocalTCPServer(t *testing.T) {
 	templateSet := entities.NewSet(false)
 	err = templateSet.PrepareSet(entities.Template, templateID)
 	assert.NoError(t, err)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	element, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
@@ -93,7 +93,7 @@ func TestExportingProcess_SendingTemplateRecordToLocalTCPServer(t *testing.T) {
 	}
 	ie = entities.NewInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
-	templateSet.AddRecord(elements, templateID)
+	templateSet.AddRecord(elements, 0, templateID)
 
 	bytesSent, err := exporter.SendSet(templateSet)
 	if err != nil {
@@ -159,7 +159,7 @@ func TestExportingProcess_SendingTemplateRecordToLocalUDPServer(t *testing.T) {
 	templateSet := entities.NewSet(false)
 	err = templateSet.PrepareSet(entities.Template, templateID)
 	assert.NoError(t, err)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	element, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
@@ -174,7 +174,7 @@ func TestExportingProcess_SendingTemplateRecordToLocalUDPServer(t *testing.T) {
 	ie = entities.NewInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 
-	templateSet.AddRecord(elements, templateID)
+	templateSet.AddRecord(elements, 0, templateID)
 
 	bytesSent, err := exporter.SendSet(templateSet)
 	if err != nil {
@@ -251,13 +251,13 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 	}
 	element2 := entities.NewInfoElementWithValue(element, nil)
 	// Hardcoding 8-bytes min data record length for testing purposes instead of creating template record
-	exporter.updateTemplate(templateID, []*entities.InfoElementWithValue{element1, element2}, 8)
+	exporter.updateTemplate(templateID, []entities.InfoElementWithValue{element1, element2}, 8)
 
 	// Create data set with 1 data record
 	dataSet := entities.NewSet(false)
 	err = dataSet.PrepareSet(entities.Data, templateID)
 	assert.NoError(t, err)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	element, err = registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
@@ -272,7 +272,7 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 	ie = entities.NewInfoElementWithValue(element, net.ParseIP("5.6.7.8"))
 	elements = append(elements, ie)
 
-	dataSet.AddRecord(elements, templateID)
+	dataSet.AddRecord(elements, 0, templateID)
 	dataRecBuff := dataSet.GetRecords()[0].GetBuffer()
 
 	bytesSent, err := exporter.SendSet(dataSet)
@@ -288,7 +288,7 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 	err = dataSet.PrepareSet(entities.Data, templateID)
 	assert.NoError(t, err)
 	for i := 0; i < 10000; i++ {
-		err := dataSet.AddRecord(elements, templateID)
+		err := dataSet.AddRecord(elements, 0, templateID)
 		assert.NoError(t, err)
 	}
 	_, err = exporter.SendSet(dataSet)
@@ -351,13 +351,13 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	}
 	element2 := entities.NewInfoElementWithValue(element, nil)
 	// Hardcoding 8-bytes min data record length for testing purposes instead of creating template record
-	exporter.updateTemplate(templateID, []*entities.InfoElementWithValue{element1, element2}, 8)
+	exporter.updateTemplate(templateID, []entities.InfoElementWithValue{element1, element2}, 8)
 
 	// Create data set with 1 data record
 	dataSet := entities.NewSet(false)
 	err = dataSet.PrepareSet(entities.Data, templateID)
 	assert.NoError(t, err)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	element, err = registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
@@ -372,7 +372,7 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	ie = entities.NewInfoElementWithValue(element, net.ParseIP("5.6.7.8"))
 	elements = append(elements, ie)
 
-	dataSet.AddRecord(elements, templateID)
+	dataSet.AddRecord(elements, 0, templateID)
 	dataRecBuff := dataSet.GetRecords()[0].GetBuffer()
 
 	bytesSent, err := exporter.SendSet(dataSet)
@@ -388,7 +388,7 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	err = dataSet.PrepareSet(entities.Data, templateID)
 	assert.NoError(t, err)
 	for i := 0; i < 100; i++ {
-		dataSet.AddRecord(elements, templateID)
+		dataSet.AddRecord(elements, 0, templateID)
 	}
 	_, err = exporter.SendSet(dataSet)
 	assert.Error(t, err)
@@ -453,7 +453,7 @@ func TestExportingProcessWithTLS(t *testing.T) {
 	templateSet := entities.NewSet(false)
 	err = templateSet.PrepareSet(entities.Template, templateID)
 	assert.NoError(t, err)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	element, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
@@ -466,7 +466,7 @@ func TestExportingProcessWithTLS(t *testing.T) {
 	}
 	ie = entities.NewInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
-	templateSet.AddRecord(elements, templateID)
+	templateSet.AddRecord(elements, 0, templateID)
 
 	bytesSent, err := exporter.SendSet(templateSet)
 	if err != nil {
@@ -538,7 +538,7 @@ func TestExportingProcessWithDTLS(t *testing.T) {
 	templateSet := entities.NewSet(false)
 	err = templateSet.PrepareSet(entities.Template, templateID)
 	assert.NoError(t, err)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	element, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
@@ -551,7 +551,7 @@ func TestExportingProcessWithDTLS(t *testing.T) {
 	}
 	ie = entities.NewInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
-	templateSet.AddRecord(elements, templateID)
+	templateSet.AddRecord(elements, 0, templateID)
 
 	bytesSent, err := exporter.SendSet(templateSet)
 	if err != nil {

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -83,14 +83,14 @@ const (
 func createMsgwithTemplateSet(isIPv6 bool) *entities.Message {
 	set := entities.NewSet(true)
 	set.PrepareSet(entities.Template, testTemplateID)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), nil)
 	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), nil)
 	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), nil)
 	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), nil)
 	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), nil)
 	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), nil)
-	var ie1, ie2, ie8 *entities.InfoElementWithValue
+	var ie1, ie2, ie8 entities.InfoElementWithValue
 	if !isIPv6 {
 		ie1 = entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 		ie2 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
@@ -107,7 +107,7 @@ func createMsgwithTemplateSet(isIPv6 bool) *entities.Message {
 	ie14 := entities.NewInfoElementWithValue(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), nil)
 
 	elements = append(elements, ie1, ie2, ie3, ie4, ie5, ie6, ie7, ie8, ie9, ie10, ie11, ie12, ie13, ie14)
-	set.AddRecord(elements, 256)
+	set.AddRecord(elements, 0, 256)
 
 	message := entities.NewMessage(true)
 	message.SetVersion(10)
@@ -128,7 +128,7 @@ func createMsgwithTemplateSet(isIPv6 bool) *entities.Message {
 func createDataMsgForSrc(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedRecord bool, isToExternal bool, isEgressDeny bool) *entities.Message {
 	set := entities.NewSet(true)
 	set.PrepareSet(entities.Data, testTemplateID)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	var egressNetworkPolicyRuleAction, ingressNetworkPolicyRulePriority, svcPort, srcAddr, dstAddr, svcAddr, flowEndTime, flowEndReason, tcpState, antreaFlowType []byte
 	var srcPod, dstPod string
 
@@ -154,7 +154,7 @@ func createDataMsgForSrc(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), []byte(srcPod))
 	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), []byte(dstPod))
 	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), svcPort)
-	var ie1, ie2, ie8, ie11 *entities.InfoElementWithValue
+	var ie1, ie2, ie8, ie11 entities.InfoElementWithValue
 	if !isIPv6 {
 		srcAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("10.0.0.1").To4())
 		dstAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("10.0.0.2").To4())
@@ -229,7 +229,7 @@ func createDataMsgForSrc(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 		elements = append(elements, ieWithValue)
 	}
 
-	err := set.AddRecord(elements, 256)
+	err := set.AddRecord(elements, 0, 256)
 	assert.NoError(t, err)
 
 	message := entities.NewMessage(true)
@@ -251,7 +251,7 @@ func createDataMsgForSrc(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 func createDataMsgForDst(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedRecord bool, isIngressReject bool, isIngressDrop bool) *entities.Message {
 	set := entities.NewSet(true)
 	set.PrepareSet(entities.Data, testTemplateID)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	var ingressNetworkPolicyRuleAction, svcPort, srcAddr, dstAddr, svcAddr, flowEndTime, flowEndReason, tcpState, antreaFlowType []byte
 	var srcPod, dstPod string
 	srcPort, _ := entities.EncodeToIEDataType(entities.Unsigned16, uint16(1234))
@@ -281,7 +281,7 @@ func createDataMsgForDst(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), []byte(srcPod))
 	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), []byte(dstPod))
 	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), svcPort)
-	var ie1, ie2, ie8, ie11 *entities.InfoElementWithValue
+	var ie1, ie2, ie8, ie11 entities.InfoElementWithValue
 	if !isIPv6 {
 		srcAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("10.0.0.1").To4())
 		dstAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("10.0.0.2").To4())
@@ -354,7 +354,7 @@ func createDataMsgForDst(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 		ieWithValue.Value = value
 		elements = append(elements, ieWithValue)
 	}
-	err := set.AddRecord(elements, 256)
+	err := set.AddRecord(elements, 0, 256)
 	assert.NoError(t, err)
 
 	message := entities.NewMessage(true)
@@ -427,7 +427,7 @@ func TestAggregateMsgByFlowKey(t *testing.T) {
 	assert.NotNil(t, aggregationProcess.flowKeyRecordMap[flowKey])
 	item := aggregationProcess.expirePriorityQueue.Peek()
 	assert.NotNil(t, item)
-	ieWithValue, exist := aggRecord.Record.GetInfoElementWithValue("sourceIPv4Address")
+	ieWithValue, _, exist := aggRecord.Record.GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
 	assert.Equal(t, net.IP{0xa, 0x0, 0x0, 0x1}, ieWithValue.Value)
 	assert.Equal(t, message.GetSet().GetRecords()[0], aggRecord.Record)
@@ -448,14 +448,17 @@ func TestAggregateMsgByFlowKey(t *testing.T) {
 	flowKey = FlowKey{"2001:0:3238:dfe1:63::fefb", "2001:0:3238:dfe1:63::fefc", 6, 1234, 5678}
 	assert.NotNil(t, aggregationProcess.flowKeyRecordMap[flowKey])
 	aggRecord = aggregationProcess.flowKeyRecordMap[flowKey]
-	ieWithValue, exist = aggRecord.Record.GetInfoElementWithValue("sourceIPv6Address")
+	ieWithValue, _, exist = aggRecord.Record.GetInfoElementWithValue("sourceIPv6Address")
 	assert.Equal(t, true, exist)
 	assert.Equal(t, net.IP{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}, ieWithValue.Value)
 	assert.Equal(t, message.GetSet().GetRecords()[0], aggRecord.Record)
 
 	// Test data record with invalid "flowEndSeconds" field
-	element, _ := message.GetSet().GetRecords()[0].GetInfoElementWithValue("flowEndSeconds")
+	element, index, exists := message.GetSet().GetRecords()[0].GetInfoElementWithValue("flowEndSeconds")
+	assert.True(t, exists)
 	element.Value = nil
+	err = message.GetSet().GetRecords()[0].SetInfoElementWithValue(index, *element)
+	assert.NoError(t, err)
 	err = aggregationProcess.AggregateMsgByFlowKey(message)
 	assert.Error(t, err)
 }
@@ -839,28 +842,28 @@ func runCorrelationAndCheckResult(t *testing.T, ap *AggregationProcess, record1,
 	}
 	if !isIntraNode && !needsCorrleation {
 		// for inter-Node deny connections, either src or dst Pod info will be resolved.
-		sourcePodName, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
-		destinationPodName, _ := aggRecord.Record.GetInfoElementWithValue("destinationPodName")
+		sourcePodName, _, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
+		destinationPodName, _, _ := aggRecord.Record.GetInfoElementWithValue("destinationPodName")
 		assert.True(t, sourcePodName.Value == "" || destinationPodName.Value == "")
-		egress, _ := aggRecord.Record.GetInfoElementWithValue("egressNetworkPolicyRuleAction")
-		ingress, _ := aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRuleAction")
+		egress, _, _ := aggRecord.Record.GetInfoElementWithValue("egressNetworkPolicyRuleAction")
+		ingress, _, _ := aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRuleAction")
 		assert.True(t, egress.Value != 0 || ingress.Value != 0)
 		assert.False(t, ap.AreCorrelatedFieldsFilled(*aggRecord))
 	} else {
-		ieWithValue, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
+		ieWithValue, _, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
 		assert.Equal(t, "pod1", ieWithValue.Value)
-		ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue("destinationPodName")
+		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationPodName")
 		assert.Equal(t, "pod2", ieWithValue.Value)
 		if !isIPv6 {
-			ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv4")
+			ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv4")
 			assert.Equal(t, net.ParseIP("192.168.0.1").To4(), ieWithValue.Value)
 		} else {
-			ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv6")
+			ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv6")
 			assert.Equal(t, net.ParseIP("2001:0:3238:BBBB:63::AAAA"), ieWithValue.Value)
 		}
-		ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue("destinationServicePort")
+		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationServicePort")
 		assert.Equal(t, uint16(4739), ieWithValue.Value)
-		ingressPriority, _ := aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRulePriority")
+		ingressPriority, _, _ := aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRulePriority")
 		assert.Equal(t, ingressPriority.Value, int32(50000))
 		assert.True(t, ap.AreCorrelatedFieldsFilled(*aggRecord))
 	}
@@ -893,39 +896,39 @@ func runAggregationAndCheckResult(t *testing.T, ap *AggregationProcess, srcRecor
 	if !isIntraNode {
 		assert.NotEqual(t, oldInactiveExpiryTime, item.inactiveExpireTime)
 	}
-	ieWithValue, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
+	ieWithValue, _, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
 	assert.Equal(t, "pod1", ieWithValue.Value)
-	ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue("destinationPodName")
+	ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationPodName")
 	assert.Equal(t, "pod2", ieWithValue.Value)
-	ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv4")
+	ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv4")
 	assert.Equal(t, net.ParseIP("192.168.0.1").To4(), ieWithValue.Value)
-	ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue("destinationServicePort")
+	ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationServicePort")
 	assert.Equal(t, uint16(4739), ieWithValue.Value)
-	ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRuleAction")
+	ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRuleAction")
 	assert.Equal(t, registry.NetworkPolicyRuleActionNoAction, ieWithValue.Value)
 	for _, e := range nonStatsElementList {
-		ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue(e)
-		expectedIE, _ := dstRecordLatest.GetInfoElementWithValue(e)
+		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue(e)
+		expectedIE, _, _ := dstRecordLatest.GetInfoElementWithValue(e)
 		assert.Equal(t, expectedIE.Value, ieWithValue.Value)
 	}
 	for _, e := range statsElementList {
-		ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue(e)
-		latestRecord, _ := dstRecordLatest.GetInfoElementWithValue(e)
+		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue(e)
+		latestRecord, _, _ := dstRecordLatest.GetInfoElementWithValue(e)
 		if !strings.Contains(e, "Delta") {
 			assert.Equalf(t, latestRecord.Value, ieWithValue.Value, "values should be equal for element %v", e)
 		} else {
-			prevRecord, _ := srcRecordLatest.GetInfoElementWithValue(e)
+			prevRecord, _, _ := srcRecordLatest.GetInfoElementWithValue(e)
 			assert.Equalf(t, prevRecord.Value.(uint64)+latestRecord.Value.(uint64), ieWithValue.Value, "values should be equal for element %v", e)
 		}
 	}
 	for i, e := range antreaSourceStatsElementList {
-		ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue(e)
-		latestRecord, _ := srcRecordLatest.GetInfoElementWithValue(statsElementList[i])
+		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue(e)
+		latestRecord, _, _ := srcRecordLatest.GetInfoElementWithValue(statsElementList[i])
 		assert.Equalf(t, latestRecord.Value, ieWithValue.Value, "values should be equal for element %v", e)
 	}
 	for i, e := range antreaDestinationStatsElementList {
-		ieWithValue, _ = aggRecord.Record.GetInfoElementWithValue(e)
-		latestRecord, _ := dstRecordLatest.GetInfoElementWithValue(statsElementList[i])
+		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue(e)
+		latestRecord, _, _ := dstRecordLatest.GetInfoElementWithValue(statsElementList[i])
 		assert.Equalf(t, latestRecord.Value, ieWithValue.Value, "values should be equal for element %v", e)
 	}
 }

--- a/pkg/kafka/consumer/protobuf/antrea.pb
+++ b/pkg/kafka/consumer/protobuf/antrea.pb
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      http: //www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/kafka/producer/convertor/test/flowtype_test.go
+++ b/pkg/kafka/producer/convertor/test/flowtype_test.go
@@ -36,7 +36,8 @@ func init() {
 func createMsgwithDataSet(t *testing.T, isV6 bool) *entities.Message {
 	set := entities.NewSet(true)
 	_ = set.PrepareSet(entities.Data, 256)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
+
 	ieNamesIANA := []string{
 		"flowStartSeconds",
 		"flowEndSeconds",
@@ -176,7 +177,7 @@ func createMsgwithDataSet(t *testing.T, isV6 bool) *entities.Message {
 		ieWithValue.Value = value
 		elements = append(elements, ieWithValue)
 	}
-	if err := set.AddRecord(elements, 256); err != nil {
+	if err := set.AddRecord(elements, 0, 256); err != nil {
 		t.Fatal("Error when adding elements to the record")
 	}
 	msg := entities.NewMessage(true)

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -243,8 +243,8 @@ func waitForAggregationToFinish(t *testing.T, ap *intermediate.AggregationProces
 	checkConn := func() (bool, error) {
 		ap.ForAllRecordsDo(copyFlowKeyRecordMap)
 		if len(flowKeyRecordMap) > 0 {
-			ie1, _ := flowKeyRecordMap[key].Record.GetInfoElementWithValue("sourcePodName")
-			ie2, _ := flowKeyRecordMap[key].Record.GetInfoElementWithValue("destinationPodName")
+			ie1, _, _ := flowKeyRecordMap[key].Record.GetInfoElementWithValue("sourcePodName")
+			ie2, _, _ := flowKeyRecordMap[key].Record.GetInfoElementWithValue("destinationPodName")
 			if ie1.Value == "pod1" && ie2.Value == "pod2" {
 				return true, nil
 			} else {

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -231,7 +231,7 @@ func matchDataRecordElements(t *testing.T, record entities.Record, isSrcNode, is
 	}
 	ianaFields = append(ianaFields, commonFields...)
 	for _, name := range ianaFields {
-		element, exist := record.GetInfoElementWithValue(name)
+		element, _, exist := record.GetInfoElementWithValue(name)
 		assert.True(t, exist)
 		switch name {
 		case "sourceIPv4Address", "sourceIPv6Address":
@@ -255,7 +255,7 @@ func matchDataRecordElements(t *testing.T, record entities.Record, isSrcNode, is
 		}
 	}
 	for _, name := range antreaCommonFields {
-		element, exist := record.GetInfoElementWithValue(name)
+		element, _, exist := record.GetInfoElementWithValue(name)
 		assert.True(t, exist)
 		switch name {
 		case "destinationClusterIPv4", "destinationClusterIPv6":
@@ -273,7 +273,7 @@ func matchDataRecordElements(t *testing.T, record entities.Record, isSrcNode, is
 		}
 	}
 	for _, name := range reverseFields {
-		element, exist := record.GetInfoElementWithValue(name)
+		element, _, exist := record.GetInfoElementWithValue(name)
 		assert.True(t, exist)
 		switch name {
 		case "reversePacketTotalCount":

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -130,7 +130,7 @@ func getTestRecord(isSrcNode, isIPv6 bool) testRecord {
 func createTemplateSet(templateID uint16, isIPv6 bool) entities.Set {
 	templateSet := entities.NewSet(false)
 	templateSet.PrepareSet(entities.Template, templateID)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	ianaFields := ianaIPv4Fields
 	if isIPv6 {
 		ianaFields = ianaIPv6Fields
@@ -157,7 +157,7 @@ func createTemplateSet(templateID uint16, isIPv6 bool) entities.Set {
 		ie := entities.NewInfoElementWithValue(element, nil)
 		elements = append(elements, ie)
 	}
-	templateSet.AddRecord(elements, templateID)
+	templateSet.AddRecord(elements, 0, templateID)
 	return templateSet
 }
 
@@ -165,17 +165,17 @@ func createDataSet(templateID uint16, isSrcNode, isIPv6 bool, isMultipleRecord b
 	dataSet := entities.NewSet(false)
 	dataSet.PrepareSet(entities.Data, templateID)
 	elements := getDataRecordElements(isSrcNode, isIPv6)
-	dataSet.AddRecord(elements, templateID)
+	dataSet.AddRecord(elements, 0, templateID)
 	if isMultipleRecord {
 		elements = getDataRecordElements(isSrcNode, isIPv6)
-		dataSet.AddRecord(elements, templateID)
+		dataSet.AddRecord(elements, 0, templateID)
 	}
 	return dataSet
 }
 
-func getDataRecordElements(isSrcNode, isIPv6 bool) []*entities.InfoElementWithValue {
+func getDataRecordElements(isSrcNode, isIPv6 bool) []entities.InfoElementWithValue {
 	testRec := getTestRecord(isSrcNode, isIPv6)
-	elements := make([]*entities.InfoElementWithValue, 0)
+	elements := make([]entities.InfoElementWithValue, 0)
 	ianaFields := ianaIPv4Fields
 	if isIPv6 {
 		ianaFields = ianaIPv6Fields
@@ -183,7 +183,7 @@ func getDataRecordElements(isSrcNode, isIPv6 bool) []*entities.InfoElementWithVa
 	ianaFields = append(ianaFields, commonFields...)
 	for _, name := range ianaFields {
 		element, _ := registry.GetInfoElement(name, registry.IANAEnterpriseID)
-		var ie *entities.InfoElementWithValue
+		var ie entities.InfoElementWithValue
 		switch name {
 		case "sourceIPv4Address", "sourceIPv6Address":
 			ie = entities.NewInfoElementWithValue(element, testRec.srcIP)
@@ -214,7 +214,7 @@ func getDataRecordElements(isSrcNode, isIPv6 bool) []*entities.InfoElementWithVa
 	}
 	for _, name := range antreaFields {
 		element, _ := registry.GetInfoElement(name, registry.AntreaEnterpriseID)
-		var ie *entities.InfoElementWithValue
+		var ie entities.InfoElementWithValue
 		switch name {
 		case "destinationClusterIPv4", "destinationClusterIPv6":
 			ie = entities.NewInfoElementWithValue(element, testRec.dstClusterIP)
@@ -233,7 +233,7 @@ func getDataRecordElements(isSrcNode, isIPv6 bool) []*entities.InfoElementWithVa
 	}
 	for _, name := range reverseFields {
 		element, _ := registry.GetInfoElement(name, registry.IANAReversedEnterpriseID)
-		var ie *entities.InfoElementWithValue
+		var ie entities.InfoElementWithValue
 		switch name {
 		case "reversePacketTotalCount":
 			ie = entities.NewInfoElementWithValue(element, testRec.revPktCount)


### PR DESCRIPTION
Moving from a slice of pointers to a slice of value for `NewInfoElementWithValue`
object. This saves quite a lot of memory consumption.

Perf results from an Antrea setup:
Before this change:
- From pprof:
```
(pprof) top
Showing nodes accounting for 19.90GB, 96.80% of 20.56GB total
Dropped 172 nodes (cum <= 0.10GB)
Showing top 10 nodes out of 54
   flat flat%  sum%    cum  cum%
  8.96GB 43.59% 43.59%   8.96GB 43.59% github.com/vmware/go-ipfix/pkg/entities.NewInfoElementWithValue (inline)
  3.46GB 16.81% 60.40%   6.68GB 32.50% github.com/vmware/go-ipfix/pkg/entities.(*dataRecord).AddInfoElement
  3.23GB 15.69% 76.09%   3.23GB 15.69% github.com/vmware/go-ipfix/pkg/entities.DecodeToIEDataType
  1.87GB 9.12% 85.21%  11.57GB 56.26% github.com/vmware/go-ipfix/pkg/collector.(*CollectingProcess).handleTCPClient.func1
  1.10GB 5.34% 90.55%   7.25GB 35.27% github.com/vmware/go-ipfix/pkg/intermediate.(*AggregationProcess).addOrUpdateRecordInMap
  0.56GB 2.72% 93.27%   0.56GB 2.72% github.com/vmware/go-ipfix/pkg/entities.NewDataRecord (inline)
  0.25GB 1.24% 94.51%   0.41GB 2.00% github.com/vmware/go-ipfix/pkg/intermediate.getFlowKeyFromRecord
  0.20GB 0.99% 95.49%   0.20GB 0.99% reflect.unsafe_NewArray
  0.16GB 0.78% 96.27%   0.16GB 0.78% net.IP.String
  0.11GB 0.52% 96.80%   0.11GB 0.52% k8s.io/apimachinery/pkg/apis/meta/v1.(*FieldsV1).UnmarshalJSON
```
- From top:
`30408 root      20   0   46.8g  45.9g  1653  73.0 636:07.78 R /flow-aggregator --config /etc/flow-aggregator/flow-aggregator.conf --logtostderr=false --log_dir=/var/log/antrea/flow-aggregato+`

After this change:
- From pprof:
```
(pprof) top
Showing nodes accounting for 11.89GB, 97.63% of 12.18GB total
Dropped 102 nodes (cum <= 0.06GB)
Showing top 10 nodes out of 48
      flat  flat%   sum%        cum   cum%
    7.18GB 59.00% 59.00%     7.18GB 59.00%  github.com/vmware/go-ipfix/pkg/entities.NewDataRecord (inline)
    1.90GB 15.60% 74.60%     1.90GB 15.60%  github.com/vmware/go-ipfix/pkg/entities.DecodeToIEDataType
    1.21GB  9.91% 84.51%    10.27GB 84.37%  github.com/vmware/go-ipfix/pkg/collector.(*CollectingProcess).handleTCPClient.func1
    0.90GB  7.41% 91.92%     0.95GB  7.80%  github.com/vmware/go-ipfix/pkg/intermediate.(*AggregationProcess).addOrUpdateRecordInMap
    0.18GB  1.47% 93.39%     0.30GB  2.47%  github.com/vmware/go-ipfix/pkg/intermediate.getFlowKeyFromRecord
    0.16GB  1.34% 94.73%     0.16GB  1.34%  reflect.unsafe_NewArray
    0.12GB  1.01% 95.74%     0.12GB  1.01%  net.IP.String
    0.08GB  0.68% 96.42%     0.11GB  0.89%  github.com/json-iterator/go.(*Iterator).ReadString
    0.08GB  0.67% 97.09%     0.08GB  0.67%  k8s.io/apimachinery/pkg/apis/meta/v1.(*FieldsV1).UnmarshalJSON
    0.07GB  0.54% 97.63%     0.07GB  0.54%  github.com/vmware/go-ipfix/pkg/collector.getFieldLength
```
- From top:
`6910 root      20   0   26.2g  25.6g 196.0  40.6 156:20.04 S /flow-aggregator --config /etc/flow-aggregator/flow-aggregator.conf --logtostderr=false --log_d+`