### PR TITLE
Remove UDP message size check

### DIFF
--- a/pkg/entities/message.go
+++ b/pkg/entities/message.go
@@ -19,10 +19,8 @@ import (
 )
 
 const (
-	MaxTcpSocketMsgSize int = 65535
-	DefaultUDPMsgSize   int = 512
-	MaxUDPMsgSize       int = 1500
-	MsgHeaderLength     int = 16
+	MaxSocketMsgSize int = 65535
+	MsgHeaderLength  int = 16
 )
 
 // Message represents IPFIX message.

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -135,7 +135,6 @@ func testExporterToCollector(address net.Addr, isSrcNode, isIPv6 bool, isMultipl
 		CollectorProtocol:   cp.GetAddress().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
-		PathMTU:             0,
 		IsEncrypted:         isEncrypted,
 		CACert:              nil,
 		CheckConnInterval:   time.Millisecond,


### PR DESCRIPTION
We decided to rely on IP fragmentation in the case of UDP transport.
This is going against the IPFIX RFC suggestion. We will revisit if
there are any issues with UDP transport in the future.