### PR TITLE
Add perf improvements to cut down allocations

### DIFF
--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -373,10 +373,9 @@ func getMessageLength(reader *bufio.Reader) (int, error) {
 // getFieldLength returns string field length for data record
 // (encoding reference: https://tools.ietf.org/html/rfc7011#appendix-A.5)
 func getFieldLength(dataBuffer *bytes.Buffer) int {
-	var lengthOneByte uint8
-	util.Decode(dataBuffer, binary.BigEndian, &lengthOneByte)
-	if lengthOneByte < 255 { // string length is less than 255
-		return int(lengthOneByte)
+	oneByte, _ := dataBuffer.ReadByte()
+	if oneByte < 255 { // string length is less than 255
+		return int(oneByte)
 	}
 	var lengthTwoBytes uint16
 	util.Decode(dataBuffer, binary.BigEndian, &lengthTwoBytes)

--- a/pkg/entities/record.go
+++ b/pkg/entities/record.go
@@ -104,9 +104,10 @@ func (b *baseRecord) GetOrderedElementList() []InfoElementWithValue {
 }
 
 func (b *baseRecord) GetInfoElementWithValue(name string) (*InfoElementWithValue, int, bool) {
-	for i, element := range b.orderedElementList {
+	for i := range b.orderedElementList {
+		element := &b.orderedElementList[i]
 		if element.Element.Name == name {
-			return &element, i, true
+			return element, i, true
 		}
 	}
 	return nil, 0, false

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -335,7 +335,9 @@ func (ep *ExportingProcess) createAndSendJSONMsg(set entities.Set) (int, error) 
 	var bytesSent int
 	for _, record := range set.GetRecords() {
 		elements := make(map[string]interface{})
-		for _, element := range record.GetOrderedElementList() {
+		orderedElements := record.GetOrderedElementList()
+		for i := range orderedElements {
+			element := &orderedElements[i]
 			elements[element.Element.Name] = element.Value
 		}
 		message := make(map[string]interface{}, 2)

--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -775,7 +775,9 @@ func getFlowKeyFromRecord(record entities.Record) (*FlowKey, bool, error) {
 }
 
 func validateDataRecord(record entities.Record) bool {
-	for _, element := range record.GetOrderedElementList() {
+	elements := record.GetOrderedElementList()
+	for i := range elements {
+		element := &elements[i]
 		if element.Value == nil {
 			// All element values should have been filled after decoding.
 			// If not, it is an invalid data record.


### PR DESCRIPTION
We reduce the allocation of objects and thereby space considerably with this change.
We saw a reduction of 5GB in total.


Before the change:

```
(pprof) exit
~/work/antrea_all/antrea$ go tool pprof -alloc_objects  ../flow_agg_perf/pprof.flow-aggregator.alloc_objects.alloc_space.inuse_objects.inuse_space.001.pb.gz 
(pprof) top
Showing nodes accounting for 739671918, 89.56% of 825867623 total
Dropped 297 nodes (cum <= 4129338)
Showing top 10 nodes out of 58
      flat  flat%   sum%        cum   cum%
 228875070 27.71% 27.71%  228875070 27.71%  github.com/vmware/go-ipfix/pkg/entities.(*baseRecord).GetInfoElementWithValue
 213911377 25.90% 53.61%  363609070 44.03%  github.com/vmware/go-ipfix/pkg/collector.(*CollectingProcess).decodeDataSet
 115902842 14.03% 67.65%  115902842 14.03%  github.com/vmware/go-ipfix/pkg/entities.DecodeToIEDataType
  72257486  8.75% 76.40%  138745786 16.80%  github.com/vmware/go-ipfix/pkg/intermediate.(*AggregationProcess).addFieldsForStatsAggregation
  29911203  3.62% 80.02%  453789801 54.95%  github.com/vmware/go-ipfix/pkg/collector.(*CollectingProcess).handleTCPClient.func1
```

After this change:

```
~/work/antrea_all/antrea$ go tool pprof -alloc_objects  ../flow_agg_perf/pprof-latest.pb.gz
(pprof) top
Showing nodes accounting for 314179179, 70.43% of 446097898 total
Dropped 360 nodes (cum <= 2230489)
Showing top 10 nodes out of 86
      flat  flat%   sum%        cum   cum%
 115034469 25.79% 25.79%  115034469 25.79%  github.com/vmware/go-ipfix/pkg/entities.DecodeBytesToIEDataType
  76967129 17.25% 43.04%   76967129 17.25%  github.com/vmware/go-ipfix/pkg/intermediate.(*AggregationProcess).addFieldsForStatsAggregation
  25063203  5.62% 48.66%   25063203  5.62%  k8s.io/klog/v2.(*loggingT).header
  17186617  3.85% 52.51%   17186617  3.85%  github.com/vmware/go-ipfix/pkg/entities.NewDataRecord (inline)
  15576148  3.49% 56.00%  132052532 29.60%  github.com/vmware/go-ipfix/pkg/intermediate.(*worker).start.func1
  14680288  3.29% 59.29%   14680288  3.29%  reflect.copyVal
  13861074  3.11% 62.40%   13861074  3.11%  net.IP.String
  12307972  2.76% 65.16%  208298636 46.69%  github.com/vmware/go-ipfix/pkg/collector.(*CollectingProcess).handleTCPClient.func1
```