### PR TITLE
Modify the basic structure `NewInfoElementWithValue`

### DIFF
--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -73,7 +73,8 @@ func printIPFIXMessage(msg *entities.Message) {
 		for i, record := range set.GetRecords() {
 			fmt.Fprintf(&buf, "  TEMPLATE RECORD-%d:\n", i)
 			for _, ie := range record.GetOrderedElementList() {
-				fmt.Fprintf(&buf, "    %s: len=%d (enterprise ID = %d) \n", ie.Element.Name, ie.Element.Len, ie.Element.EnterpriseId)
+				elem := ie.GetInfoElement()
+				fmt.Fprintf(&buf, "    %s: len=%d (enterprise ID = %d) \n", elem.Name, elem.Len, elem.EnterpriseId)
 			}
 		}
 	} else {
@@ -81,7 +82,127 @@ func printIPFIXMessage(msg *entities.Message) {
 		for i, record := range set.GetRecords() {
 			fmt.Fprintf(&buf, "  DATA RECORD-%d:\n", i)
 			for _, ie := range record.GetOrderedElementList() {
-				fmt.Fprintf(&buf, "    %s: %v \n", ie.Element.Name, ie.Value)
+				elem := ie.GetInfoElement()
+				switch elem.DataType {
+				case entities.Unsigned8:
+					val, err := ie.GetUnsigned8Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Unsigned16:
+					val, err := ie.GetUnsigned16Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Unsigned32:
+					val, err := ie.GetUnsigned32Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Unsigned64:
+					val, err := ie.GetUnsigned64Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Signed8:
+					val, err := ie.GetSigned8Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Signed16:
+					val, err := ie.GetSigned16Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Signed32:
+					val, err := ie.GetSigned32Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Signed64:
+					val, err := ie.GetSigned64Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Float32:
+					val, err := ie.GetFloat32Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Float64:
+					val, err := ie.GetFloat64Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Boolean:
+					val, err := ie.GetBooleanValue()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.DateTimeSeconds:
+					val, err := ie.GetUnsigned32Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.DateTimeMilliseconds:
+					val, err := ie.GetUnsigned64Value()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.DateTimeMicroseconds, entities.DateTimeNanoseconds:
+					err := fmt.Errorf("API does not support micro and nano seconds types yet")
+					fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+				case entities.MacAddress:
+					val, err := ie.GetMacAddressValue()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.Ipv4Address, entities.Ipv6Address:
+					val, err := ie.GetIPAddressValue()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				case entities.String:
+					val, err := ie.GetStringValue()
+					if err != nil {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+					} else {
+						fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, val)
+					}
+				default:
+					err := fmt.Errorf("API supports only valid information elements with datatypes given in RFC7011")
+					fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, err)
+				}
 			}
 		}
 	}

--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -45,9 +45,9 @@ const (
 )
 
 var elementsWithValueIPv4 = []entities.InfoElementWithValue{
-	{Element: &entities.InfoElement{Name: "sourceIPv4Address", ElementId: 8, DataType: 18, EnterpriseId: 0, Len: 4}, Value: nil},
-	{Element: &entities.InfoElement{Name: "destinationIPv4Address", ElementId: 12, DataType: 18, EnterpriseId: 0, Len: 4}, Value: nil},
-	{Element: &entities.InfoElement{Name: "destinationNodeName", ElementId: 105, DataType: 13, EnterpriseId: 55829, Len: 65535}, Value: nil},
+	entities.NewIPAddressInfoElement(&entities.InfoElement{Name: "sourceIPv4Address", ElementId: 8, DataType: 18, EnterpriseId: 0, Len: 4}, nil),
+	entities.NewIPAddressInfoElement(&entities.InfoElement{Name: "destinationIPv4Address", ElementId: 12, DataType: 18, EnterpriseId: 0, Len: 4}, nil),
+	entities.NewStringInfoElement(&entities.InfoElement{Name: "destinationNodeName", ElementId: 105, DataType: 13, EnterpriseId: 55829, Len: 65535}, ""),
 }
 
 func init() {
@@ -264,7 +264,7 @@ func TestCollectingProcess_DecodeTemplateRecord(t *testing.T) {
 	assert.NotNil(t, templateSet, "Template record should be stored in message flowset")
 	sourceIPv4Address, _, exist := templateSet.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
-	assert.Equal(t, uint32(0), sourceIPv4Address.Element.EnterpriseId, "Template record is not stored correctly.")
+	assert.Equal(t, uint32(0), sourceIPv4Address.GetInfoElement().EnterpriseId, "Template record is not stored correctly.")
 	// Invalid version
 	templateRecord := []byte{0, 9, 0, 40, 95, 40, 211, 236, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 24, 1, 0, 0, 3, 0, 8, 0, 4, 0, 12, 0, 4, 128, 105, 255, 255, 0, 0, 218, 21}
 	_, err = cp.decodePacket(bytes.NewBuffer(templateRecord), address.String())
@@ -308,7 +308,8 @@ func TestCollectingProcess_DecodeDataRecord(t *testing.T) {
 	ipAddress := net.IP([]byte{1, 2, 3, 4})
 	sourceIPv4Address, _, exist := set.GetRecords()[0].GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
-	assert.Equal(t, ipAddress, sourceIPv4Address.Value, "sourceIPv4Address should be decoded and stored correctly.")
+	ipVal, _ := sourceIPv4Address.GetIPAddressValue()
+	assert.Equal(t, ipAddress, ipVal, "sourceIPv4Address should be decoded and stored correctly.")
 	// Malformed data record
 	dataRecord := []byte{0, 10, 0, 33, 95, 40, 212, 159, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0}
 	_, err = cp.decodePacket(bytes.NewBuffer(dataRecord), address.String())
@@ -466,7 +467,8 @@ func TestTCPCollectingProcessIPv6(t *testing.T) {
 	assert.NotNil(t, template)
 	ie, _, exist := message.GetSet().GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
 	assert.True(t, exist)
-	assert.Equal(t, net.ParseIP("2001:0:3238:DFE1:63::FEFB"), ie.Value)
+	ipVal, _ := ie.GetIPAddressValue()
+	assert.Equal(t, net.ParseIP("2001:0:3238:DFE1:63::FEFB"), ipVal)
 }
 
 func TestUDPCollectingProcessIPv6(t *testing.T) {
@@ -495,7 +497,8 @@ func TestUDPCollectingProcessIPv6(t *testing.T) {
 	assert.NotNil(t, template)
 	ie, _, exist := message.GetSet().GetRecords()[0].GetInfoElementWithValue("sourceIPv6Address")
 	assert.True(t, exist)
-	assert.Equal(t, net.ParseIP("2001:0:3238:DFE1:63::FEFB"), ie.Value)
+	ipVal, _ := ie.GetIPAddressValue()
+	assert.Equal(t, net.ParseIP("2001:0:3238:DFE1:63::FEFB"), ipVal)
 }
 
 func getCollectorInput(network string, isEncrypted bool, isIPv6 bool) CollectorInput {

--- a/pkg/entities/ie.go
+++ b/pkg/entities/ie.go
@@ -93,13 +93,6 @@ type InfoElement struct {
 	Len uint16
 }
 
-// InfoElementWithValue represents mapping from element to value for data records
-type InfoElementWithValue struct {
-	Element *InfoElement
-	Value   interface{}
-	Length  int
-}
-
 func NewInfoElement(name string, ieID uint16, ieType IEDataType, entID uint32, len uint16) *InfoElement {
 	return &InfoElement{
 		Name:         name,
@@ -107,12 +100,6 @@ func NewInfoElement(name string, ieID uint16, ieType IEDataType, entID uint32, l
 		DataType:     ieType,
 		EnterpriseId: entID,
 		Len:          len,
-	}
-}
-
-func NewInfoElementWithValue(element *InfoElement, value interface{}) InfoElementWithValue {
-	return InfoElementWithValue{
-		element, value, 0,
 	}
 }
 
@@ -172,8 +159,8 @@ func IsValidDataType(tp IEDataType) bool {
 	return tp != InvalidDataType
 }
 
-// DecodeToIEDataType is to decode to specific type
-func DecodeToIEDataType(dataType IEDataType, val interface{}) (interface{}, error) {
+// decodeToIEDataType is to decode to specific type. This is only used for testing.
+func decodeToIEDataType(dataType IEDataType, val interface{}) (interface{}, error) {
 	value, ok := val.([]byte)
 	if !ok {
 		return nil, fmt.Errorf("error when converting value to []bytes for decoding")
@@ -224,7 +211,135 @@ func DecodeToIEDataType(dataType IEDataType, val interface{}) (interface{}, erro
 	}
 }
 
-// EncodeToIEDataType is to encode data to specific type to the buff
+// DecodeAndCreateInfoElementWithValue takes in the info element and its value in bytes, and
+// returns appropriate InfoElementWithValue.
+func DecodeAndCreateInfoElementWithValue(element *InfoElement, value []byte) (InfoElementWithValue, error) {
+	switch element.DataType {
+	case Unsigned8:
+		var val uint8
+		if value == nil {
+			val = 0
+		} else {
+			val = value[0]
+		}
+		return NewUnsigned8InfoElement(element, val), nil
+	case Unsigned16:
+		var val uint16
+		if value == nil {
+			val = 0
+		} else {
+			val = binary.BigEndian.Uint16(value)
+		}
+		return NewUnsigned16InfoElement(element, val), nil
+	case Unsigned32:
+		var val uint32
+		if value == nil {
+			val = 0
+		} else {
+			val = binary.BigEndian.Uint32(value)
+		}
+		return NewUnsigned32InfoElement(element, val), nil
+	case Unsigned64:
+		var val uint64
+		if value == nil {
+			val = 0
+		} else {
+			val = binary.BigEndian.Uint64(value)
+		}
+		return NewUnsigned64InfoElement(element, val), nil
+	case Signed8:
+		var val int8
+		if value == nil {
+			val = 0
+		} else {
+			val = int8(value[0])
+		}
+		return NewSigned8InfoElement(element, val), nil
+	case Signed16:
+		var val int16
+		if value == nil {
+			val = 0
+		} else {
+			val = int16(binary.BigEndian.Uint16(value))
+		}
+		return NewSigned16InfoElement(element, val), nil
+	case Signed32:
+		var val int32
+		if value == nil {
+			val = 0
+		} else {
+			val = int32(binary.BigEndian.Uint32(value))
+		}
+		return NewSigned32InfoElement(element, val), nil
+	case Signed64:
+		var val int64
+		if value == nil {
+			val = 0
+		}
+		val = int64(binary.BigEndian.Uint64(value))
+		return NewSigned64InfoElement(element, val), nil
+	case Float32:
+		var val float32
+		if value == nil {
+			val = 0
+		} else {
+			val = math.Float32frombits(binary.BigEndian.Uint32(value))
+		}
+		return NewFloat32InfoElement(element, val), nil
+	case Float64:
+		var val float64
+		if value == nil {
+			val = 0
+		} else {
+			val = math.Float64frombits(binary.BigEndian.Uint64(value))
+		}
+		return NewFloat64InfoElement(element, val), nil
+	case Boolean:
+		if value == nil {
+			return NewBoolInfoElement(element, false), nil
+		}
+		if int8(value[0]) == 1 {
+			return NewBoolInfoElement(element, true), nil
+		} else {
+			return NewBoolInfoElement(element, false), nil
+		}
+	case DateTimeSeconds:
+		var val uint32
+		if value == nil {
+			val = 0
+		} else {
+			val = binary.BigEndian.Uint32(value)
+		}
+		return NewDateTimeSecondsInfoElement(element, val), nil
+	case DateTimeMilliseconds:
+		var val uint64
+		if value == nil {
+			val = 0
+		} else {
+			val = binary.BigEndian.Uint64(value)
+		}
+		return NewDateTimeMillisecondsInfoElement(element, val), nil
+	case DateTimeMicroseconds, DateTimeNanoseconds:
+		return nil, fmt.Errorf("API does not support micro and nano seconds types yet")
+	case MacAddress:
+		return NewMacAddressInfoElement(element, value), nil
+	case Ipv4Address, Ipv6Address:
+		return NewIPAddressInfoElement(element, value), nil
+	case String:
+		var val string
+		if value == nil {
+			val = ""
+		} else {
+			val = string(value)
+		}
+		return NewStringInfoElement(element, val), nil
+	default:
+		return nil, fmt.Errorf("API supports only valid information elements with datatypes given in RFC7011")
+	}
+}
+
+// EncodeToIEDataType is to encode data to specific type to the buff. This is only
+// used for testing.
 func EncodeToIEDataType(dataType IEDataType, val interface{}) ([]byte, error) {
 	switch dataType {
 	case Unsigned8:
@@ -390,76 +505,77 @@ func EncodeToIEDataType(dataType IEDataType, val interface{}) ([]byte, error) {
 	return nil, fmt.Errorf("API supports only valid information elements with datatypes given in RFC7011")
 }
 
-// encodeToBuff is to encode data to specific type to the buff
-func encodeToBuff(dataType IEDataType, val interface{}, length int, buffer []byte, index int) error {
-	if index+length > len(buffer) {
+// encodeInfoElementValueToBuff is to encode data to specific type to the buff
+func encodeInfoElementValueToBuff(element InfoElementWithValue, buffer []byte, index int) error {
+	infoElem := element.GetInfoElement()
+	if index+element.GetLength() > len(buffer) {
 		return fmt.Errorf("buffer size is not enough for encoding")
 	}
-	switch dataType {
+	switch infoElem.DataType {
 	case Unsigned8:
-		v, ok := val.(uint8)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type uint8", val)
+		v, err := element.GetUnsigned8Value()
+		if err != nil {
+			return err
 		}
 		copy(buffer[index:index+1], []byte{v})
 	case Unsigned16:
-		v, ok := val.(uint16)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type uint16", val)
+		v, err := element.GetUnsigned16Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint16(buffer[index:], v)
 	case Unsigned32:
-		v, ok := val.(uint32)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type uint32", val)
+		v, err := element.GetUnsigned32Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint32(buffer[index:], v)
 	case Unsigned64:
-		v, ok := val.(uint64)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type uint64", val)
+		v, err := element.GetUnsigned64Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint64(buffer[index:], v)
 	case Signed8:
-		v, ok := val.(int8)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type int8", val)
+		v, err := element.GetSigned8Value()
+		if err != nil {
+			return err
 		}
 		copy(buffer[index:index+1], []byte{byte(v)})
 	case Signed16:
-		v, ok := val.(int16)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type int16", val)
+		v, err := element.GetSigned16Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint16(buffer[index:], uint16(v))
 	case Signed32:
-		v, ok := val.(int32)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type int32", val)
+		v, err := element.GetSigned32Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint32(buffer[index:], uint32(v))
 	case Signed64:
-		v, ok := val.(int64)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type int64", val)
+		v, err := element.GetSigned64Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint64(buffer[index:], uint64(v))
 	case Float32:
-		v, ok := val.(float32)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type float32", val)
+		v, err := element.GetFloat32Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint32(buffer[index:], math.Float32bits(v))
 	case Float64:
-		v, ok := val.(float64)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type float64", val)
+		v, err := element.GetFloat64Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint64(buffer[index:], math.Float64bits(v))
 	case Boolean:
-		v, ok := val.(bool)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type bool", val)
+		v, err := element.GetBooleanValue()
+		if err != nil {
+			return err
 		}
 		// Following boolean spec from RFC7011
 		indicator := byte(int8(1))
@@ -468,15 +584,15 @@ func encodeToBuff(dataType IEDataType, val interface{}, length int, buffer []byt
 		}
 		copy(buffer[index:index+1], []byte{indicator})
 	case DateTimeSeconds:
-		v, ok := val.(uint32)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type uint32", val)
+		v, err := element.GetUnsigned32Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint32(buffer[index:], v)
 	case DateTimeMilliseconds:
-		v, ok := val.(uint64)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type uint64", val)
+		v, err := element.GetUnsigned64Value()
+		if err != nil {
+			return err
 		}
 		binary.BigEndian.PutUint64(buffer[index:], v)
 		// Currently only supporting seconds and milliseconds
@@ -485,16 +601,16 @@ func encodeToBuff(dataType IEDataType, val interface{}, length int, buffer []byt
 		return fmt.Errorf("API does not support micro and nano seconds types yet")
 	case MacAddress:
 		// Expects net.Hardware type
-		v, ok := val.(net.HardwareAddr)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type net.HardwareAddr for this element", val)
+		v, err := element.GetMacAddressValue()
+		if err != nil {
+			return err
 		}
 		copy(buffer[index:], v)
 	case Ipv4Address:
 		// Expects net.IP type
-		v, ok := val.(net.IP)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type net.IP for this element", val)
+		v, err := element.GetIPAddressValue()
+		if err != nil {
+			return err
 		}
 		if ipv4Add := v.To4(); ipv4Add != nil {
 			copy(buffer[index:], ipv4Add)
@@ -503,9 +619,9 @@ func encodeToBuff(dataType IEDataType, val interface{}, length int, buffer []byt
 		}
 	case Ipv6Address:
 		// Expects net.IP type
-		v, ok := val.(net.IP)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type net.IP for this element", val)
+		v, err := element.GetIPAddressValue()
+		if err != nil {
+			return err
 		}
 		if ipv6Add := v.To16(); ipv6Add != nil {
 			copy(buffer[index:], ipv6Add)
@@ -513,9 +629,9 @@ func encodeToBuff(dataType IEDataType, val interface{}, length int, buffer []byt
 			return fmt.Errorf("provided IPv6 address %v is not of correct length", v)
 		}
 	case String:
-		v, ok := val.(string)
-		if !ok {
-			return fmt.Errorf("val argument %v is not of type string for this element", val)
+		v, err := element.GetStringValue()
+		if err != nil {
+			return err
 		}
 		if len(v) < 255 {
 			buffer[index] = uint8(len(v))
@@ -533,17 +649,4 @@ func encodeToBuff(dataType IEDataType, val interface{}, length int, buffer []byt
 		return fmt.Errorf("API supports only valid information elements with datatypes given in RFC7011")
 	}
 	return nil
-}
-
-func setInfoElementLen(element *InfoElementWithValue) {
-	if element.Element.DataType != String {
-		element.Length = int(element.Element.Len)
-	} else {
-		v := element.Value.(string)
-		if len(v) < 255 {
-			element.Length = len(v) + 1
-		} else {
-			element.Length = len(v) + 3
-		}
-	}
 }

--- a/pkg/entities/ie_test.go
+++ b/pkg/entities/ie_test.go
@@ -37,13 +37,13 @@ func TestDecodeToIEDataType(t *testing.T) {
 	for _, data := range valData {
 		buff, err := EncodeToIEDataType(data.dataType, data.value)
 		assert.Nil(t, err)
-		v, err := DecodeToIEDataType(data.dataType, buff)
+		v, err := decodeToIEDataType(data.dataType, buff)
 		assert.Nil(t, err)
 		assert.Equal(t, data.expectedDecode, v)
 	}
 	// Handle string differently since it cannot be directly write to buffer
 	s := "Test String"
-	v, err := DecodeToIEDataType(String, []byte(s))
+	v, err := decodeToIEDataType(String, []byte(s))
 	assert.Nil(t, err)
 	assert.Equal(t, s, v)
 }
@@ -66,28 +66,10 @@ func TestEncodeToIEDataType(t *testing.T) {
 	assert.Equal(t, []byte{0x4, 0x54, 0x65, 0x73, 0x74}, buff)
 }
 
-func TestEncodeToBuff(t *testing.T) {
-	for _, data := range valData {
-		var err error
-		buff := make([]byte, InfoElementLength[data.dataType])
-		if data.dataType == Boolean {
-			err = encodeToBuff(data.dataType, data.expectedDecode, data.length, buff, 0)
-		} else {
-			err = encodeToBuff(data.dataType, data.value, data.length, buff, 0)
-		}
-		assert.Nil(t, err)
-		assert.Equal(t, data.expectedEncode, buff)
-	}
-	buff := make([]byte, 5)
-	s := "Test"
-	err := encodeToBuff(String, s, 5, buff, 0)
-	assert.Nil(t, err)
-	assert.Equal(t, []byte{0x4, 0x54, 0x65, 0x73, 0x74}, buff)
-}
-
 func TestNewInfoElementWithValue(t *testing.T) {
 	ip := net.ParseIP("10.0.0.1")
-	element := NewInfoElementWithValue(&InfoElement{"sourceIPv4Address", 8, 18, 0, 4}, ip)
-	assert.Equal(t, element.Element.Name, "sourceIPv4Address")
-	assert.Equal(t, element.Value, ip)
+	element := NewIPAddressInfoElement(&InfoElement{"sourceIPv4Address", 8, 18, 0, 4}, ip)
+	assert.Equal(t, element.GetInfoElement().Name, "sourceIPv4Address")
+	val, _ := element.GetIPAddressValue()
+	assert.Equal(t, val, ip)
 }

--- a/pkg/entities/ie_value.go
+++ b/pkg/entities/ie_value.go
@@ -1,0 +1,2374 @@
+package entities
+
+import (
+	"fmt"
+	"net"
+)
+
+type InfoElementWithValue interface {
+	// GetInfoElement retrieves the info element. This is called after AddInfoElement.
+	// TODO: Handle error to make it more robust if it is called prior to AddInfoElement.
+	GetInfoElement() *InfoElement
+	AddInfoElement(infoElement *InfoElement)
+	GetUnsigned8Value() (uint8, error)
+	GetUnsigned16Value() (uint16, error)
+	GetUnsigned32Value() (uint32, error)
+	GetUnsigned64Value() (uint64, error)
+	GetSigned8Value() (int8, error)
+	GetSigned16Value() (int16, error)
+	GetSigned32Value() (int32, error)
+	GetSigned64Value() (int64, error)
+	GetFloat32Value() (float32, error)
+	GetFloat64Value() (float64, error)
+	GetBooleanValue() (bool, error)
+	GetMacAddressValue() (net.HardwareAddr, error)
+	GetStringValue() (string, error)
+	GetIPAddressValue() (net.IP, error)
+	SetUnsigned8Value(val uint8) error
+	SetUnsigned16Value(val uint16) error
+	SetUnsigned32Value(val uint32) error
+	SetUnsigned64Value(val uint64) error
+	SetSigned8Value(val int8) error
+	SetSigned16Value(val int16) error
+	SetSigned32Value(val int32) error
+	SetSigned64Value(val int64) error
+	SetFloat32Value(val float32) error
+	SetFloat64Value(val float64) error
+	SetBooleanValue(val bool) error
+	SetMacAddressValue(val net.HardwareAddr) error
+	SetStringValue(val string) error
+	SetIPAddressValue(val net.IP) error
+	IsValueEmpty() bool
+	GetLength() int
+	ResetValue()
+}
+
+type Unsigned8InfoElement struct {
+	value   uint8
+	element *InfoElement
+}
+
+func NewUnsigned8InfoElement(element *InfoElement, val uint8) *Unsigned8InfoElement {
+	return &Unsigned8InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (u8 *Unsigned8InfoElement) GetInfoElement() *InfoElement {
+	return u8.element
+}
+
+func (u8 *Unsigned8InfoElement) AddInfoElement(infoElement *InfoElement) {
+	u8.element = infoElement
+}
+
+func (u8 *Unsigned8InfoElement) GetUnsigned8Value() (uint8, error) {
+	return u8.value, nil
+}
+
+func (u8 *Unsigned8InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u8 *Unsigned8InfoElement) SetUnsigned8Value(val uint8) error {
+	u8.value = val
+	return nil
+}
+
+func (u8 *Unsigned8InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u8 *Unsigned8InfoElement) IsValueEmpty() bool {
+	return u8.value == 0
+}
+
+func (u8 *Unsigned8InfoElement) GetLength() int {
+	return int(u8.element.Len)
+}
+
+func (u8 *Unsigned8InfoElement) ResetValue() {
+	u8.value = 0
+}
+
+type Unsigned16InfoElement struct {
+	value   uint16
+	element *InfoElement
+}
+
+func NewUnsigned16InfoElement(element *InfoElement, val uint16) *Unsigned16InfoElement {
+	return &Unsigned16InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (u16 *Unsigned16InfoElement) GetInfoElement() *InfoElement {
+	return u16.element
+}
+
+func (u16 *Unsigned16InfoElement) AddInfoElement(infoElement *InfoElement) {
+	u16.element = infoElement
+}
+
+func (u16 *Unsigned16InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetUnsigned16Value() (uint16, error) {
+	return u16.value, nil
+}
+
+func (u16 *Unsigned16InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u16 *Unsigned16InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetUnsigned16Value(val uint16) error {
+	u16.value = val
+	return nil
+}
+
+func (u16 *Unsigned16InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u16 *Unsigned16InfoElement) IsValueEmpty() bool {
+	return u16.value == 0
+}
+
+func (u16 *Unsigned16InfoElement) GetLength() int {
+	return int(u16.element.Len)
+}
+
+func (u16 *Unsigned16InfoElement) ResetValue() {
+	u16.value = 0
+}
+
+type Unsigned32InfoElement struct {
+	value   uint32
+	element *InfoElement
+}
+
+func NewUnsigned32InfoElement(element *InfoElement, val uint32) *Unsigned32InfoElement {
+	return &Unsigned32InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (u32 *Unsigned32InfoElement) GetInfoElement() *InfoElement {
+	return u32.element
+}
+
+func (u32 *Unsigned32InfoElement) AddInfoElement(infoElement *InfoElement) {
+	u32.element = infoElement
+}
+
+func (u32 *Unsigned32InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetUnsigned32Value() (uint32, error) {
+	return u32.value, nil
+}
+
+func (u32 *Unsigned32InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u32 *Unsigned32InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetUnsigned32Value(val uint32) error {
+	u32.value = val
+	return nil
+}
+
+func (u32 *Unsigned32InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u32 *Unsigned32InfoElement) IsValueEmpty() bool {
+	return u32.value == 0
+}
+
+func (u32 *Unsigned32InfoElement) GetLength() int {
+	return int(u32.element.Len)
+}
+
+func (u32 *Unsigned32InfoElement) ResetValue() {
+	u32.value = 0
+}
+
+type Unsigned64InfoElement struct {
+	value   uint64
+	element *InfoElement
+}
+
+func NewUnsigned64InfoElement(element *InfoElement, val uint64) *Unsigned64InfoElement {
+	return &Unsigned64InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (u64 *Unsigned64InfoElement) GetInfoElement() *InfoElement {
+	return u64.element
+}
+
+func (u64 *Unsigned64InfoElement) AddInfoElement(infoElement *InfoElement) {
+	u64.element = infoElement
+}
+
+func (u64 *Unsigned64InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetUnsigned64Value() (uint64, error) {
+	return u64.value, nil
+}
+
+func (u64 *Unsigned64InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (u64 *Unsigned64InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetUnsigned64Value(val uint64) error {
+	u64.value = val
+	return nil
+}
+
+func (u64 *Unsigned64InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (u64 *Unsigned64InfoElement) IsValueEmpty() bool {
+	return u64.value == 0
+}
+
+func (u64 *Unsigned64InfoElement) GetLength() int {
+	return int(u64.element.Len)
+}
+
+func (u64 *Unsigned64InfoElement) ResetValue() {
+	u64.value = 0
+}
+
+type Signed8InfoElement struct {
+	value   int8
+	element *InfoElement
+}
+
+func NewSigned8InfoElement(element *InfoElement, val int8) *Signed8InfoElement {
+	return &Signed8InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (i8 *Signed8InfoElement) GetInfoElement() *InfoElement {
+	return i8.element
+}
+
+func (i8 *Signed8InfoElement) AddInfoElement(infoElement *InfoElement) {
+	i8.element = infoElement
+}
+
+func (i8 *Signed8InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetSigned8Value() (int8, error) {
+	return i8.value, nil
+}
+
+func (i8 *Signed8InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i8 *Signed8InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetSigned8Value(val int8) error {
+	i8.value = val
+	return nil
+}
+
+func (i8 *Signed8InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i8 *Signed8InfoElement) IsValueEmpty() bool {
+	return i8.value == 0
+}
+
+func (i8 *Signed8InfoElement) GetLength() int {
+	return int(i8.element.Len)
+}
+
+func (i8 *Signed8InfoElement) ResetValue() {
+	i8.value = 0
+}
+
+type Signed16InfoElement struct {
+	value   int16
+	element *InfoElement
+}
+
+func NewSigned16InfoElement(element *InfoElement, val int16) *Signed16InfoElement {
+	return &Signed16InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (i16 *Signed16InfoElement) GetInfoElement() *InfoElement {
+	return i16.element
+}
+
+func (i16 *Signed16InfoElement) AddInfoElement(infoElement *InfoElement) {
+	i16.element = infoElement
+}
+
+func (i16 *Signed16InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetSigned16Value() (int16, error) {
+	return i16.value, nil
+}
+
+func (i16 *Signed16InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i16 *Signed16InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetSigned16Value(val int16) error {
+	i16.value = val
+	return nil
+}
+
+func (i16 *Signed16InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i16 *Signed16InfoElement) IsValueEmpty() bool {
+	return i16.value == 0
+}
+
+func (i16 *Signed16InfoElement) GetLength() int {
+	return int(i16.element.Len)
+}
+
+func (i16 *Signed16InfoElement) ResetValue() {
+	i16.value = 0
+}
+
+type Signed32InfoElement struct {
+	value   int32
+	element *InfoElement
+}
+
+func NewSigned32InfoElement(element *InfoElement, val int32) *Signed32InfoElement {
+	return &Signed32InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (i32 *Signed32InfoElement) GetInfoElement() *InfoElement {
+	return i32.element
+}
+
+func (i32 *Signed32InfoElement) AddInfoElement(infoElement *InfoElement) {
+	i32.element = infoElement
+}
+
+func (i32 *Signed32InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetSigned32Value() (int32, error) {
+	return i32.value, nil
+}
+
+func (i32 *Signed32InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i32 *Signed32InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetSigned32Value(val int32) error {
+	i32.value = val
+	return nil
+}
+
+func (i32 *Signed32InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i32 *Signed32InfoElement) IsValueEmpty() bool {
+	return i32.value == 0
+}
+
+func (i32 *Signed32InfoElement) GetLength() int {
+	return int(i32.element.Len)
+}
+
+func (i32 *Signed32InfoElement) ResetValue() {
+	i32.value = 0
+}
+
+type Signed64InfoElement struct {
+	value   int64
+	element *InfoElement
+}
+
+func NewSigned64InfoElement(element *InfoElement, val int64) *Signed64InfoElement {
+	return &Signed64InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (i64 *Signed64InfoElement) GetInfoElement() *InfoElement {
+	return i64.element
+}
+
+func (i64 *Signed64InfoElement) AddInfoElement(infoElement *InfoElement) {
+	i64.element = infoElement
+}
+
+func (i64 *Signed64InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetSigned64Value() (int64, error) {
+	return i64.value, nil
+}
+
+func (i64 *Signed64InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (i64 *Signed64InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetSigned64Value(val int64) error {
+	i64.value = val
+	return nil
+}
+
+func (i64 *Signed64InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (i64 *Signed64InfoElement) IsValueEmpty() bool {
+	return i64.value == 0
+}
+
+func (i64 *Signed64InfoElement) GetLength() int {
+	return int(i64.element.Len)
+}
+
+func (i64 *Signed64InfoElement) ResetValue() {
+	i64.value = 0
+}
+
+type Float32InfoElement struct {
+	value   float32
+	element *InfoElement
+}
+
+func NewFloat32InfoElement(element *InfoElement, val float32) *Float32InfoElement {
+	return &Float32InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (f32 *Float32InfoElement) GetInfoElement() *InfoElement {
+	return f32.element
+}
+
+func (f32 *Float32InfoElement) AddInfoElement(infoElement *InfoElement) {
+	f32.element = infoElement
+}
+
+func (f32 *Float32InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetFloat32Value() (float32, error) {
+	return f32.value, nil
+}
+
+func (f32 *Float32InfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f32 *Float32InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetFloat32Value(val float32) error {
+	f32.value = val
+	return nil
+}
+
+func (f32 *Float32InfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f32 *Float32InfoElement) IsValueEmpty() bool {
+	return f32.value == 0
+}
+
+func (f32 *Float32InfoElement) GetLength() int {
+	return int(f32.element.Len)
+}
+
+func (f32 *Float32InfoElement) ResetValue() {
+	f32.value = 0
+}
+
+type Float64InfoElement struct {
+	value   float64
+	element *InfoElement
+}
+
+func NewFloat64InfoElement(element *InfoElement, val float64) *Float64InfoElement {
+	return &Float64InfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (f64 *Float64InfoElement) GetInfoElement() *InfoElement {
+	return f64.element
+}
+
+func (f64 *Float64InfoElement) AddInfoElement(infoElement *InfoElement) {
+	f64.element = infoElement
+}
+
+func (f64 *Float64InfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetFloat64Value() (float64, error) {
+	return f64.value, nil
+}
+
+func (f64 *Float64InfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (f64 *Float64InfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetFloat64Value(val float64) error {
+	f64.value = val
+	return nil
+}
+
+func (f64 *Float64InfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (f64 *Float64InfoElement) IsValueEmpty() bool {
+	return f64.value == 0
+}
+
+func (f64 *Float64InfoElement) GetLength() int {
+	return int(f64.element.Len)
+}
+
+func (f64 *Float64InfoElement) ResetValue() {
+	f64.value = 0
+}
+
+type BooleanInfoElement struct {
+	value   bool
+	element *InfoElement
+}
+
+func NewBoolInfoElement(element *InfoElement, val bool) *BooleanInfoElement {
+	return &BooleanInfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (b *BooleanInfoElement) GetInfoElement() *InfoElement {
+	return b.element
+}
+
+func (b *BooleanInfoElement) AddInfoElement(infoElement *InfoElement) {
+	b.element = infoElement
+}
+
+func (b *BooleanInfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetBooleanValue() (bool, error) {
+	return b.value, nil
+}
+
+func (b *BooleanInfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (b *BooleanInfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetBooleanValue(val bool) error {
+	b.value = val
+	return nil
+}
+
+func (b *BooleanInfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (b *BooleanInfoElement) IsValueEmpty() bool {
+	return b.value == false
+}
+
+func (b *BooleanInfoElement) GetLength() int {
+	return int(b.element.Len)
+}
+
+func (b *BooleanInfoElement) ResetValue() {
+	b.value = false
+}
+
+type MacAddressInfoElement struct {
+	value   net.HardwareAddr
+	element *InfoElement
+}
+
+func NewMacAddressInfoElement(element *InfoElement, val net.HardwareAddr) *MacAddressInfoElement {
+	return &MacAddressInfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (mac *MacAddressInfoElement) GetInfoElement() *InfoElement {
+	return mac.element
+}
+
+func (mac *MacAddressInfoElement) AddInfoElement(infoElement *InfoElement) {
+	mac.element = infoElement
+}
+
+func (mac *MacAddressInfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return mac.value, nil
+}
+
+func (mac *MacAddressInfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (mac *MacAddressInfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	mac.value = val
+	return nil
+}
+
+func (mac *MacAddressInfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (mac *MacAddressInfoElement) IsValueEmpty() bool {
+	return mac.value == nil
+}
+
+func (mac *MacAddressInfoElement) GetLength() int {
+	return int(mac.element.Len)
+}
+
+func (mac *MacAddressInfoElement) ResetValue() {
+	mac.value = nil
+}
+
+type StringInfoElement struct {
+	element *InfoElement
+	value   string
+	length  int
+}
+
+func NewStringInfoElement(element *InfoElement, val string) *StringInfoElement {
+	return &StringInfoElement{
+		element: element,
+		value:   val,
+		length:  len(val),
+	}
+}
+
+func (s *StringInfoElement) GetInfoElement() *InfoElement {
+	return s.element
+}
+
+func (s *StringInfoElement) AddInfoElement(infoElement *InfoElement) {
+	s.element = infoElement
+}
+
+func (s *StringInfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) GetStringValue() (string, error) {
+	return s.value, nil
+}
+
+func (s *StringInfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (s *StringInfoElement) SetValue(value string) {
+	s.value = value
+}
+
+func (s *StringInfoElement) GetLength() int {
+	if len(s.value) < 255 {
+		return len(s.value) + 1
+	} else {
+		return len(s.value) + 3
+	}
+}
+
+func (s *StringInfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) SetStringValue(val string) error {
+	s.value = val
+	return nil
+}
+
+func (s *StringInfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (s *StringInfoElement) IsValueEmpty() bool {
+	return s.value == ""
+}
+
+func (s *StringInfoElement) ResetValue() {
+	s.value = ""
+}
+
+type DateTimeSecondsInfoElement struct {
+	value   uint32
+	element *InfoElement
+}
+
+func NewDateTimeSecondsInfoElement(element *InfoElement, val uint32) *DateTimeSecondsInfoElement {
+	return &DateTimeSecondsInfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetInfoElement() *InfoElement {
+	return dsec.element
+}
+
+func (dsec *DateTimeSecondsInfoElement) AddInfoElement(infoElement *InfoElement) {
+	dsec.element = infoElement
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetUnsigned32Value() (uint32, error) {
+	return dsec.value, nil
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetUnsigned32Value(val uint32) error {
+	dsec.value = val
+	return nil
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dsec *DateTimeSecondsInfoElement) IsValueEmpty() bool {
+	return dsec.value == 0
+}
+
+func (dsec *DateTimeSecondsInfoElement) GetLength() int {
+	return int(dsec.element.Len)
+}
+
+func (dsec *DateTimeSecondsInfoElement) ResetValue() {
+	dsec.value = 0
+}
+
+type DateTimeMillisecondsInfoElement struct {
+	value   uint64
+	element *InfoElement
+}
+
+func NewDateTimeMillisecondsInfoElement(element *InfoElement, val uint64) *DateTimeMillisecondsInfoElement {
+	return &DateTimeMillisecondsInfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetInfoElement() *InfoElement {
+	return dmsec.element
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) AddInfoElement(infoElement *InfoElement) {
+	dmsec.element = infoElement
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetUnsigned64Value() (uint64, error) {
+	return dmsec.value, nil
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetIPAddressValue() (net.IP, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetUnsigned64Value(val uint64) error {
+	dmsec.value = val
+	return nil
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) SetIPAddressValue(val net.IP) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) IsValueEmpty() bool {
+	return dmsec.value == 0
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) GetLength() int {
+	return int(dmsec.element.Len)
+}
+
+func (dmsec *DateTimeMillisecondsInfoElement) ResetValue() {
+	dmsec.value = 0
+}
+
+type IPAddressInfoElement struct {
+	element *InfoElement
+	value   net.IP
+}
+
+func NewIPAddressInfoElement(element *InfoElement, val net.IP) *IPAddressInfoElement {
+	return &IPAddressInfoElement{
+		element: element,
+		value:   val,
+	}
+}
+
+func (ip *IPAddressInfoElement) GetInfoElement() *InfoElement {
+	return ip.element
+}
+
+func (ip *IPAddressInfoElement) AddInfoElement(infoElement *InfoElement) {
+	ip.element = infoElement
+}
+
+func (ip *IPAddressInfoElement) GetUnsigned8Value() (uint8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetUnsigned16Value() (uint16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetUnsigned32Value() (uint32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetUnsigned64Value() (uint64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetSigned8Value() (int8, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetSigned16Value() (int16, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetSigned32Value() (int32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetSigned64Value() (int64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetFloat32Value() (float32, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetFloat64Value() (float64, error) {
+	return 0, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetBooleanValue() (bool, error) {
+	return false, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetMacAddressValue() (net.HardwareAddr, error) {
+	return nil, fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetStringValue() (string, error) {
+	return "", fmt.Errorf("accessing value of wrong data type")
+}
+
+func (ip *IPAddressInfoElement) GetIPAddressValue() (net.IP, error) {
+	return ip.value, nil
+}
+
+func (ip *IPAddressInfoElement) SetUnsigned8Value(val uint8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetUnsigned16Value(val uint16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetUnsigned32Value(val uint32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetUnsigned64Value(val uint64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetSigned8Value(val int8) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetSigned16Value(val int16) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetSigned32Value(val int32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetSigned64Value(val int64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetFloat32Value(val float32) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetFloat64Value(val float64) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetBooleanValue(val bool) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetMacAddressValue(val net.HardwareAddr) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetStringValue(val string) error {
+	return fmt.Errorf("setting value with wrong data type: %T", val)
+}
+
+func (ip *IPAddressInfoElement) SetIPAddressValue(val net.IP) error {
+	ip.value = val
+	return nil
+}
+
+func (ip *IPAddressInfoElement) IsValueEmpty() bool {
+	return ip.value == nil
+}
+
+func (ip *IPAddressInfoElement) GetLength() int {
+	return int(ip.element.Len)
+}
+
+func (ip *IPAddressInfoElement) ResetValue() {
+	ip.value = nil
+}

--- a/pkg/entities/set.go
+++ b/pkg/entities/set.go
@@ -134,8 +134,8 @@ func (s *set) AddRecord(elements []InfoElementWithValue, templateID uint16) erro
 	} else {
 		return fmt.Errorf("set type is not supported")
 	}
-	for i := range elements {
-		err := record.AddInfoElement(&elements[i])
+	for _, element := range elements {
+		err := record.AddInfoElement(element)
 		if err != nil {
 			return err
 		}
@@ -159,7 +159,7 @@ func (s *set) AddRecordWithExtraElements(elements []InfoElementWithValue, numExt
 		return fmt.Errorf("set type is not supported")
 	}
 	for i := range elements {
-		err := record.AddInfoElement(&elements[i])
+		err := record.AddInfoElement(elements[i])
 		if err != nil {
 			return err
 		}

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -15,8 +15,8 @@ const (
 func TestAddRecordIPv4Addresses(t *testing.T) {
 	// Test with template encodingSet
 	elements := make([]InfoElementWithValue, 0)
-	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
-	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
+	ie1 := NewIPAddressInfoElement(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+	ie2 := NewIPAddressInfoElement(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
 	encodingSet := NewSet(false)
 	err := encodingSet.PrepareSet(Template, testTemplateID)
@@ -31,8 +31,8 @@ func TestAddRecordIPv4Addresses(t *testing.T) {
 	err = encodingSet.PrepareSet(Data, testTemplateID)
 	assert.NoError(t, err)
 	elements = make([]InfoElementWithValue, 0)
-	ie1 = NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1").To4())
-	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("10.0.0.2").To4())
+	ie1 = NewIPAddressInfoElement(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1").To4())
+	ie2 = NewIPAddressInfoElement(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("10.0.0.2").To4())
 	elements = append(elements, ie1, ie2)
 	err = encodingSet.AddRecord(elements, 256)
 	assert.NoError(t, err)
@@ -42,8 +42,8 @@ func TestAddRecordIPv4Addresses(t *testing.T) {
 func TestAddRecordIPv6Addresses(t *testing.T) {
 	// Test with template record
 	elements := make([]InfoElementWithValue, 0)
-	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv6Address", 27, 19, 0, 16), nil)
-	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), nil)
+	ie1 := NewIPAddressInfoElement(NewInfoElement("sourceIPv6Address", 27, 19, 0, 16), nil)
+	ie2 := NewIPAddressInfoElement(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), nil)
 	elements = append(elements, ie1, ie2)
 	newSet := NewSet(false)
 	err := newSet.PrepareSet(Template, testTemplateID)
@@ -55,8 +55,8 @@ func TestAddRecordIPv6Addresses(t *testing.T) {
 	err = newSet.PrepareSet(Data, testTemplateID)
 	assert.NoError(t, err)
 	elements = make([]InfoElementWithValue, 0)
-	ie1 = NewInfoElementWithValue(NewInfoElement("sourceIPv6Address", 27, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
-	ie2 = NewInfoElementWithValue(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
+	ie1 = NewIPAddressInfoElement(NewInfoElement("sourceIPv6Address", 27, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
+	ie2 = NewIPAddressInfoElement(NewInfoElement("destinationIPv6Address", 28, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
 	elements = append(elements, ie1, ie2)
 	newSet.AddRecord(elements, 256)
 	srcIP := []byte(net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
@@ -87,8 +87,8 @@ func TestGetHeaderBuffer(t *testing.T) {
 
 func TestGetRecords(t *testing.T) {
 	elements := make([]InfoElementWithValue, 0)
-	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
-	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
+	ie1 := NewIPAddressInfoElement(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+	ie2 := NewIPAddressInfoElement(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
 	newSet := NewSet(true)
 	err := newSet.PrepareSet(Template, testTemplateID)
@@ -99,8 +99,8 @@ func TestGetRecords(t *testing.T) {
 
 func TestGetNumberOfRecords(t *testing.T) {
 	elements := make([]InfoElementWithValue, 0)
-	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
-	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
+	ie1 := NewIPAddressInfoElement(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+	ie2 := NewIPAddressInfoElement(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
 	newSet := NewSet(true)
 	err := newSet.PrepareSet(Template, testTemplateID)
@@ -111,8 +111,8 @@ func TestGetNumberOfRecords(t *testing.T) {
 
 func TestSet_UpdateLenInHeader(t *testing.T) {
 	elements := make([]InfoElementWithValue, 0)
-	ie1 := NewInfoElementWithValue(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
-	ie2 := NewInfoElementWithValue(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
+	ie1 := NewIPAddressInfoElement(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+	ie2 := NewIPAddressInfoElement(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
 	elements = append(elements, ie1, ie2)
 	setForDecoding := NewSet(true)
 	err := setForDecoding.PrepareSet(Template, testTemplateID)

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -48,7 +48,7 @@ func (m *MockRecord) EXPECT() *MockRecordMockRecorder {
 }
 
 // AddInfoElement mocks base method
-func (m *MockRecord) AddInfoElement(arg0 *entities.InfoElementWithValue) error {
+func (m *MockRecord) AddInfoElement(arg0 entities.InfoElementWithValue) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddInfoElement", arg0)
 	ret0, _ := ret[0].(error)
@@ -90,10 +90,10 @@ func (mr *MockRecordMockRecorder) GetFieldCount() *gomock.Call {
 }
 
 // GetInfoElementWithValue mocks base method
-func (m *MockRecord) GetInfoElementWithValue(arg0 string) (*entities.InfoElementWithValue, int, bool) {
+func (m *MockRecord) GetInfoElementWithValue(arg0 string) (entities.InfoElementWithValue, int, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInfoElementWithValue", arg0)
-	ret0, _ := ret[0].(*entities.InfoElementWithValue)
+	ret0, _ := ret[0].(entities.InfoElementWithValue)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(bool)
 	return ret0, ret1, ret2
@@ -173,18 +173,4 @@ func (m *MockRecord) PrepareRecord() error {
 func (mr *MockRecordMockRecorder) PrepareRecord() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareRecord", reflect.TypeOf((*MockRecord)(nil).PrepareRecord))
-}
-
-// SetInfoElementWithValue mocks base method
-func (m *MockRecord) SetInfoElementWithValue(arg0 int, arg1 entities.InfoElementWithValue) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetInfoElementWithValue", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetInfoElementWithValue indicates an expected call of SetInfoElementWithValue
-func (mr *MockRecordMockRecorder) SetInfoElementWithValue(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInfoElementWithValue", reflect.TypeOf((*MockRecord)(nil).SetInfoElementWithValue), arg0, arg1)
 }

--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -85,13 +85,13 @@ func TestExportingProcess_SendingTemplateRecordToLocalTCPServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	ie := entities.NewInfoElementWithValue(element, nil)
+	ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 	element, err = registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	ie = entities.NewInfoElementWithValue(element, nil)
+	ie, _ = entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 	templateSet.AddRecord(elements, templateID)
 
@@ -164,14 +164,14 @@ func TestExportingProcess_SendingTemplateRecordToLocalUDPServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	ie := entities.NewInfoElementWithValue(element, nil)
+	ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 
 	element, err = registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	ie = entities.NewInfoElementWithValue(element, nil)
+	ie, _ = entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 
 	templateSet.AddRecord(elements, templateID)
@@ -244,12 +244,12 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	element1 := entities.NewInfoElementWithValue(element, nil)
+	element1, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	element, err = registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	element2 := entities.NewInfoElementWithValue(element, nil)
+	element2, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	// Hardcoding 8-bytes min data record length for testing purposes instead of creating template record
 	exporter.updateTemplate(templateID, []entities.InfoElementWithValue{element1, element2}, 8)
 
@@ -262,14 +262,14 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	ie := entities.NewInfoElementWithValue(element, net.ParseIP("1.2.3.4"))
+	ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, net.ParseIP("1.2.3.4"))
 	elements = append(elements, ie)
 
 	element, err = registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	ie = entities.NewInfoElementWithValue(element, net.ParseIP("5.6.7.8"))
+	ie, _ = entities.DecodeAndCreateInfoElementWithValue(element, net.ParseIP("5.6.7.8"))
 	elements = append(elements, ie)
 
 	dataSet.AddRecord(elements, templateID)
@@ -344,12 +344,12 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	element1 := entities.NewInfoElementWithValue(element, nil)
+	element1, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	element, err = registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	element2 := entities.NewInfoElementWithValue(element, nil)
+	element2, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	// Hardcoding 8-bytes min data record length for testing purposes instead of creating template record
 	exporter.updateTemplate(templateID, []entities.InfoElementWithValue{element1, element2}, 8)
 
@@ -362,14 +362,14 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	ie := entities.NewInfoElementWithValue(element, net.ParseIP("1.2.3.4"))
+	ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, net.ParseIP("1.2.3.4"))
 	elements = append(elements, ie)
 
 	element, err = registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	ie = entities.NewInfoElementWithValue(element, net.ParseIP("5.6.7.8"))
+	ie, _ = entities.DecodeAndCreateInfoElementWithValue(element, net.ParseIP("5.6.7.8"))
 	elements = append(elements, ie)
 
 	dataSet.AddRecord(elements, templateID)
@@ -458,13 +458,13 @@ func TestExportingProcessWithTLS(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	ie := entities.NewInfoElementWithValue(element, nil)
+	ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 	element, err = registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	ie = entities.NewInfoElementWithValue(element, nil)
+	ie, _ = entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 	templateSet.AddRecord(elements, templateID)
 
@@ -543,13 +543,13 @@ func TestExportingProcessWithDTLS(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	ie := entities.NewInfoElementWithValue(element, nil)
+	ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 	element, err = registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	ie = entities.NewInfoElementWithValue(element, nil)
+	ie, _ = entities.DecodeAndCreateInfoElementWithValue(element, nil)
 	elements = append(elements, ie)
 	templateSet.AddRecord(elements, templateID)
 

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -84,27 +84,27 @@ func createMsgwithTemplateSet(isIPv6 bool) *entities.Message {
 	set := entities.NewSet(true)
 	set.PrepareSet(entities.Template, testTemplateID)
 	elements := make([]entities.InfoElementWithValue, 0)
-	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), nil)
-	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), nil)
-	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), nil)
-	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), nil)
-	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), nil)
-	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), nil)
+	ie3 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), 0)
+	ie4 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), 0)
+	ie5 := entities.NewUnsigned8InfoElement(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), 0)
+	ie6 := entities.NewStringInfoElement(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), "")
+	ie7 := entities.NewStringInfoElement(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), "")
+	ie9 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), 0)
 	var ie1, ie2, ie8 entities.InfoElementWithValue
 	if !isIPv6 {
-		ie1 = entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
-		ie2 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
-		ie8 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIPv4", 106, 18, registry.AntreaEnterpriseID, 4), nil)
+		ie1 = entities.NewIPAddressInfoElement(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
+		ie2 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), nil)
+		ie8 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationClusterIPv4", 106, 18, registry.AntreaEnterpriseID, 4), nil)
 	} else {
-		ie1 = entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv6Address", 8, 19, 0, 16), nil)
-		ie2 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv6Address", 12, 19, 0, 16), nil)
-		ie8 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIPv6", 106, 19, registry.AntreaEnterpriseID, 16), nil)
+		ie1 = entities.NewIPAddressInfoElement(entities.NewInfoElement("sourceIPv6Address", 8, 19, 0, 16), nil)
+		ie2 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationIPv6Address", 12, 19, 0, 16), nil)
+		ie8 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationClusterIPv6", 106, 19, registry.AntreaEnterpriseID, 16), nil)
 	}
-	ie10 := entities.NewInfoElementWithValue(entities.NewInfoElement("flowEndSeconds", 151, 14, 0, 4), nil)
-	ie11 := entities.NewInfoElementWithValue(entities.NewInfoElement("flowType", 137, 1, registry.AntreaEnterpriseID, 1), nil)
-	ie12 := entities.NewInfoElementWithValue(entities.NewInfoElement("ingressNetworkPolicyRuleAction", 139, 1, registry.AntreaEnterpriseID, 1), nil)
-	ie13 := entities.NewInfoElementWithValue(entities.NewInfoElement("egressNetworkPolicyRuleAction", 140, 1, registry.AntreaEnterpriseID, 1), nil)
-	ie14 := entities.NewInfoElementWithValue(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), nil)
+	ie10 := entities.NewDateTimeSecondsInfoElement(entities.NewInfoElement("flowEndSeconds", 151, 14, 0, 4), 0)
+	ie11 := entities.NewUnsigned8InfoElement(entities.NewInfoElement("flowType", 137, 1, registry.AntreaEnterpriseID, 1), 0)
+	ie12 := entities.NewUnsigned8InfoElement(entities.NewInfoElement("ingressNetworkPolicyRuleAction", 139, 1, registry.AntreaEnterpriseID, 1), 0)
+	ie13 := entities.NewUnsigned8InfoElement(entities.NewInfoElement("egressNetworkPolicyRuleAction", 140, 1, registry.AntreaEnterpriseID, 1), 0)
+	ie14 := entities.NewSigned32InfoElement(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), 0)
 
 	elements = append(elements, ie1, ie2, ie3, ie4, ie5, ie6, ie7, ie8, ie9, ie10, ie11, ie12, ie13, ie14)
 	set.AddRecord(elements, 256)
@@ -129,76 +129,60 @@ func createDataMsgForSrc(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 	set := entities.NewSet(true)
 	set.PrepareSet(entities.Data, testTemplateID)
 	elements := make([]entities.InfoElementWithValue, 0)
-	var egressNetworkPolicyRuleAction, ingressNetworkPolicyRulePriority, svcPort, srcAddr, dstAddr, svcAddr, flowEndTime, flowEndReason, tcpState, antreaFlowType []byte
 	var srcPod, dstPod string
-
-	srcPort, _ := entities.EncodeToIEDataType(entities.Unsigned16, uint16(1234))
-	dstPort, _ := entities.EncodeToIEDataType(entities.Unsigned16, uint16(5678))
-	proto, _ := entities.EncodeToIEDataType(entities.Unsigned8, uint8(6))
-	svcPort, _ = entities.EncodeToIEDataType(entities.Unsigned16, uint16(4739))
-	ingressNetworkPolicyRuleAction, _ := entities.EncodeToIEDataType(entities.Unsigned8, registry.NetworkPolicyRuleActionNoAction)
-	if isEgressDeny {
-		egressNetworkPolicyRuleAction, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.NetworkPolicyRuleActionDrop)
-	} else {
-		egressNetworkPolicyRuleAction, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.NetworkPolicyRuleActionNoAction)
-	}
 	srcPod = "pod1"
 	if !isIntraNode {
 		dstPod = ""
 	} else {
 		dstPod = "pod2"
 	}
-	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), srcPort)
-	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), dstPort)
-	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), proto)
-	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), []byte(srcPod))
-	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), []byte(dstPod))
-	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), svcPort)
-	var ie1, ie2, ie8, ie11 entities.InfoElementWithValue
+	ie3 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), uint16(1234))
+	ie4 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), uint16(5678))
+	ie5 := entities.NewUnsigned8InfoElement(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), uint8(6))
+	ie6 := entities.NewStringInfoElement(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), srcPod)
+	ie7 := entities.NewStringInfoElement(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), dstPod)
+	ie9 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), uint16(4739))
+	var ie1, ie2, ie8, ie10, ie11, ie12, ie13, ie14, ie15, ie16 entities.InfoElementWithValue
 	if !isIPv6 {
-		srcAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("10.0.0.1").To4())
-		dstAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("10.0.0.2").To4())
-		svcAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("192.168.0.1").To4())
-		ie1 = entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), srcAddr)
-		ie2 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), dstAddr)
-		ie8 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIPv4", 106, 18, registry.AntreaEnterpriseID, 4), svcAddr)
+		ie1 = entities.NewIPAddressInfoElement(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1").To4())
+		ie2 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("10.0.0.2").To4())
+		ie8 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationClusterIPv4", 106, 18, registry.AntreaEnterpriseID, 4), net.ParseIP("192.168.0.1").To4())
 	} else {
-		srcAddr, _ = entities.EncodeToIEDataType(entities.Ipv6Address, net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
-		dstAddr, _ = entities.EncodeToIEDataType(entities.Ipv6Address, net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
-		svcAddr, _ = entities.EncodeToIEDataType(entities.Ipv6Address, net.ParseIP("2001:0:3238:BBBB:63::AAAA"))
-		ie1 = entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv6Address", 8, 19, 0, 16), srcAddr)
-		ie2 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv6Address", 12, 19, 0, 16), dstAddr)
-		ie8 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIPv6", 106, 19, registry.AntreaEnterpriseID, 16), svcAddr)
+		ie1 = entities.NewIPAddressInfoElement(entities.NewInfoElement("sourceIPv6Address", 8, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
+		ie2 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationIPv6Address", 12, 19, 0, 16), net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
+		ie8 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationClusterIPv6", 106, 19, registry.AntreaEnterpriseID, 16), net.ParseIP("2001:0:3238:BBBB:63::AAAA"))
 	}
+	tmpFlowEndSecs, _ := registry.GetInfoElement("flowEndSeconds", registry.IANAEnterpriseID)
+	tmpFlowEndReason, _ := registry.GetInfoElement("flowEndReason", registry.IANAEnterpriseID)
+	tmpTCPState, _ := registry.GetInfoElement("tcpState", registry.AntreaEnterpriseID)
+
 	if !isUpdatedRecord {
-		flowEndTime, _ = entities.EncodeToIEDataType(entities.DateTimeSeconds, uint32(1))
-		flowEndReason, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.ActiveTimeoutReason)
-		tcpState, _ = entities.EncodeToIEDataType(entities.String, "ESTABLISHED")
+		ie10 = entities.NewDateTimeSecondsInfoElement(tmpFlowEndSecs, uint32(1))
+		ie12 = entities.NewUnsigned8InfoElement(tmpFlowEndReason, registry.ActiveTimeoutReason)
+		ie13 = entities.NewStringInfoElement(tmpTCPState, "ESTABLISHED")
 	} else {
-		flowEndTime, _ = entities.EncodeToIEDataType(entities.DateTimeSeconds, uint32(10))
-		flowEndReason, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.EndOfFlowReason)
-		tcpState, _ = entities.EncodeToIEDataType(entities.String, "TIME_WAIT")
+		ie10 = entities.NewDateTimeSecondsInfoElement(tmpFlowEndSecs, uint32(10))
+		ie12 = entities.NewUnsigned8InfoElement(tmpFlowEndReason, registry.EndOfFlowReason)
+		ie13 = entities.NewStringInfoElement(tmpTCPState, "TIME_WAIT")
 	}
-	tmpElement, _ := registry.GetInfoElement("flowEndSeconds", registry.IANAEnterpriseID)
-	ie10 := entities.NewInfoElementWithValue(tmpElement, flowEndTime)
+
 	if isToExternal {
-		antreaFlowType, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.FlowTypeToExternal)
-		ingressNetworkPolicyRulePriority, _ = entities.EncodeToIEDataType(entities.Signed32, int32(50000))
+		ie11 = entities.NewUnsigned8InfoElement(entities.NewInfoElement("flowType", 137, 1, registry.AntreaEnterpriseID, 1), registry.FlowTypeToExternal)
+		ie16 = entities.NewSigned32InfoElement(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), int32(50000))
 	} else if !isIntraNode {
-		antreaFlowType, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.FlowTypeInterNode)
-		ingressNetworkPolicyRulePriority, _ = entities.EncodeToIEDataType(entities.Signed32, int32(0))
+		ie11 = entities.NewUnsigned8InfoElement(entities.NewInfoElement("flowType", 137, 1, registry.AntreaEnterpriseID, 1), registry.FlowTypeInterNode)
+		ie16 = entities.NewSigned32InfoElement(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), int32(0))
 	} else {
-		antreaFlowType, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.FlowTypeIntraNode)
-		ingressNetworkPolicyRulePriority, _ = entities.EncodeToIEDataType(entities.Signed32, int32(50000))
+		ie11 = entities.NewUnsigned8InfoElement(entities.NewInfoElement("flowType", 137, 1, registry.AntreaEnterpriseID, 1), registry.FlowTypeIntraNode)
+		ie16 = entities.NewSigned32InfoElement(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), int32(50000))
 	}
-	ie11 = entities.NewInfoElementWithValue(entities.NewInfoElement("flowType", 137, 1, registry.AntreaEnterpriseID, 1), antreaFlowType)
-	tmpElement, _ = registry.GetInfoElement("flowEndReason", registry.IANAEnterpriseID)
-	ie12 := entities.NewInfoElementWithValue(tmpElement, flowEndReason)
-	tmpElement, _ = registry.GetInfoElement("tcpState", registry.AntreaEnterpriseID)
-	ie13 := entities.NewInfoElementWithValue(tmpElement, tcpState)
-	ie14 := entities.NewInfoElementWithValue(entities.NewInfoElement("ingressNetworkPolicyRuleAction", 139, 1, registry.AntreaEnterpriseID, 1), ingressNetworkPolicyRuleAction)
-	ie15 := entities.NewInfoElementWithValue(entities.NewInfoElement("egressNetworkPolicyRuleAction", 140, 1, registry.AntreaEnterpriseID, 1), egressNetworkPolicyRuleAction)
-	ie16 := entities.NewInfoElementWithValue(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), ingressNetworkPolicyRulePriority)
+	ie14 = entities.NewUnsigned8InfoElement(entities.NewInfoElement("ingressNetworkPolicyRuleAction", 139, 1, registry.AntreaEnterpriseID, 1), registry.NetworkPolicyRuleActionNoAction)
+
+	if isEgressDeny {
+		ie15 = entities.NewUnsigned8InfoElement(entities.NewInfoElement("egressNetworkPolicyRuleAction", 140, 1, registry.AntreaEnterpriseID, 1), registry.NetworkPolicyRuleActionDrop)
+	} else {
+		ie15 = entities.NewUnsigned8InfoElement(entities.NewInfoElement("egressNetworkPolicyRuleAction", 140, 1, registry.AntreaEnterpriseID, 1), registry.NetworkPolicyRuleActionNoAction)
+	}
 
 	elements = append(elements, ie1, ie2, ie3, ie4, ie5, ie6, ie7, ie8, ie9, ie10, ie11, ie12, ie13, ie14, ie15, ie16)
 	// Add all elements in statsElements.
@@ -209,23 +193,22 @@ func createDataMsgForSrc(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 		} else {
 			e, _ = registry.GetInfoElement(element, registry.IANAReversedEnterpriseID)
 		}
-		ieWithValue := entities.NewInfoElementWithValue(e, nil)
-		var value []byte
+
+		var ieWithValue entities.InfoElementWithValue
 		switch element {
 		case "packetTotalCount", "reversePacketTotalCount":
 			if !isUpdatedRecord {
-				value, _ = entities.EncodeToIEDataType(entities.Unsigned64, uint64(500))
+				ieWithValue = entities.NewUnsigned64InfoElement(e, uint64(500))
 			} else {
-				value, _ = entities.EncodeToIEDataType(entities.Unsigned64, uint64(1000))
+				ieWithValue = entities.NewUnsigned64InfoElement(e, uint64(1000))
 			}
 		case "packetDeltaCount", "reversePacketDeltaCount":
 			if !isUpdatedRecord {
-				value, _ = entities.EncodeToIEDataType(entities.Unsigned64, uint64(0))
+				ieWithValue = entities.NewUnsigned64InfoElement(e, uint64(0))
 			} else {
-				value, _ = entities.EncodeToIEDataType(entities.Unsigned64, uint64(500))
+				ieWithValue = entities.NewUnsigned64InfoElement(e, uint64(500))
 			}
 		}
-		ieWithValue.Value = value
 		elements = append(elements, ieWithValue)
 	}
 
@@ -252,79 +235,82 @@ func createDataMsgForDst(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 	set := entities.NewSet(true)
 	set.PrepareSet(entities.Data, testTemplateID)
 	elements := make([]entities.InfoElementWithValue, 0)
-	var ingressNetworkPolicyRuleAction, svcPort, srcAddr, dstAddr, svcAddr, flowEndTime, flowEndReason, tcpState, antreaFlowType []byte
-	var srcPod, dstPod string
-	srcPort, _ := entities.EncodeToIEDataType(entities.Unsigned16, uint16(1234))
-	dstPort, _ := entities.EncodeToIEDataType(entities.Unsigned16, uint16(5678))
-	proto, _ := entities.EncodeToIEDataType(entities.Unsigned8, uint8(6))
+	var srcAddr, dstAddr, svcAddr []byte
+	var flowEndTime uint32
+	var flowEndReason, ingressNetworkPolicyRuleAction, antreaFlowType uint8
+	var srcPod, dstPod, tcpState string
+	var svcPort uint16
+	srcPort := uint16(1234)
+	dstPort := uint16(5678)
+	proto := uint8(6)
 	if isIngressReject {
-		ingressNetworkPolicyRuleAction, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.NetworkPolicyRuleActionReject)
+		ingressNetworkPolicyRuleAction = registry.NetworkPolicyRuleActionReject
 	} else if isIngressDrop {
-		ingressNetworkPolicyRuleAction, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.NetworkPolicyRuleActionDrop)
+		ingressNetworkPolicyRuleAction = registry.NetworkPolicyRuleActionDrop
 	} else {
-		ingressNetworkPolicyRuleAction, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.NetworkPolicyRuleActionNoAction)
+		ingressNetworkPolicyRuleAction = registry.NetworkPolicyRuleActionNoAction
 	}
-	egressNetworkPolicyRuleAction, _ := entities.EncodeToIEDataType(entities.Unsigned8, registry.NetworkPolicyRuleActionNoAction)
-	ingressNetworkPolicyRulePriority, _ := entities.EncodeToIEDataType(entities.Signed32, int32(50000))
+	egressNetworkPolicyRuleAction := registry.NetworkPolicyRuleActionNoAction
+	ingressNetworkPolicyRulePriority := int32(50000)
 	if !isIntraNode {
-		svcPort, _ = entities.EncodeToIEDataType(entities.Unsigned16, uint16(0))
+		svcPort = uint16(0)
 		srcPod = ""
 	} else {
-		svcPort, _ = entities.EncodeToIEDataType(entities.Unsigned16, uint16(4739))
+		svcPort = uint16(4739)
 		srcPod = "pod1"
 	}
 	dstPod = "pod2"
 
-	ie3 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), srcPort)
-	ie4 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), dstPort)
-	ie5 := entities.NewInfoElementWithValue(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), proto)
-	ie6 := entities.NewInfoElementWithValue(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), []byte(srcPod))
-	ie7 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), []byte(dstPod))
-	ie9 := entities.NewInfoElementWithValue(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), svcPort)
+	ie3 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("sourceTransportPort", 7, 2, 0, 2), srcPort)
+	ie4 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("destinationTransportPort", 11, 2, 0, 2), dstPort)
+	ie5 := entities.NewUnsigned8InfoElement(entities.NewInfoElement("protocolIdentifier", 4, 1, 0, 1), proto)
+	ie6 := entities.NewStringInfoElement(entities.NewInfoElement("sourcePodName", 101, 13, registry.AntreaEnterpriseID, 65535), srcPod)
+	ie7 := entities.NewStringInfoElement(entities.NewInfoElement("destinationPodName", 103, 13, registry.AntreaEnterpriseID, 65535), dstPod)
+	ie9 := entities.NewUnsigned16InfoElement(entities.NewInfoElement("destinationServicePort", 107, 2, registry.AntreaEnterpriseID, 2), svcPort)
 	var ie1, ie2, ie8, ie11 entities.InfoElementWithValue
 	if !isIPv6 {
-		srcAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("10.0.0.1").To4())
-		dstAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("10.0.0.2").To4())
-		svcAddr, _ = entities.EncodeToIEDataType(entities.Ipv4Address, net.ParseIP("0.0.0.0").To4())
-		ie1 = entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), srcAddr)
-		ie2 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), dstAddr)
-		ie8 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIPv4", 106, 18, registry.AntreaEnterpriseID, 4), svcAddr)
+		srcAddr = net.ParseIP("10.0.0.1").To4()
+		dstAddr = net.ParseIP("10.0.0.2").To4()
+		svcAddr = net.ParseIP("0.0.0.0").To4()
+		ie1 = entities.NewIPAddressInfoElement(entities.NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), srcAddr)
+		ie2 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), dstAddr)
+		ie8 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationClusterIPv4", 106, 18, registry.AntreaEnterpriseID, 4), svcAddr)
 	} else {
-		srcAddr, _ = entities.EncodeToIEDataType(entities.Ipv6Address, net.ParseIP("2001:0:3238:DFE1:63::FEFB"))
-		dstAddr, _ = entities.EncodeToIEDataType(entities.Ipv6Address, net.ParseIP("2001:0:3238:DFE1:63::FEFC"))
+		srcAddr = net.ParseIP("2001:0:3238:DFE1:63::FEFB")
+		dstAddr = net.ParseIP("2001:0:3238:DFE1:63::FEFC")
 		if !isIntraNode {
-			svcAddr, _ = entities.EncodeToIEDataType(entities.Ipv6Address, net.ParseIP("::0"))
+			svcAddr = net.ParseIP("::0")
 		} else {
-			svcAddr, _ = entities.EncodeToIEDataType(entities.Ipv6Address, net.ParseIP("2001:0:3238:BBBB:63::AAAA"))
+			svcAddr = net.ParseIP("2001:0:3238:BBBB:63::AAAA")
 		}
-		ie1 = entities.NewInfoElementWithValue(entities.NewInfoElement("sourceIPv6Address", 8, 19, 0, 16), srcAddr)
-		ie2 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationIPv6Address", 12, 19, 0, 16), dstAddr)
-		ie8 = entities.NewInfoElementWithValue(entities.NewInfoElement("destinationClusterIPv6", 106, 19, registry.AntreaEnterpriseID, 16), svcAddr)
+		ie1 = entities.NewIPAddressInfoElement(entities.NewInfoElement("sourceIPv6Address", 8, 19, 0, 16), srcAddr)
+		ie2 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationIPv6Address", 12, 19, 0, 16), dstAddr)
+		ie8 = entities.NewIPAddressInfoElement(entities.NewInfoElement("destinationClusterIPv6", 106, 19, registry.AntreaEnterpriseID, 16), svcAddr)
 	}
 	if !isUpdatedRecord {
-		flowEndTime, _ = entities.EncodeToIEDataType(entities.DateTimeSeconds, uint32(1))
-		flowEndReason, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.ActiveTimeoutReason)
-		tcpState, _ = entities.EncodeToIEDataType(entities.String, "ESTABLISHED")
+		flowEndTime = uint32(1)
+		flowEndReason = registry.ActiveTimeoutReason
+		tcpState = "ESTABLISHED"
 	} else {
-		flowEndTime, _ = entities.EncodeToIEDataType(entities.DateTimeSeconds, uint32(10))
-		flowEndReason, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.EndOfFlowReason)
-		tcpState, _ = entities.EncodeToIEDataType(entities.String, "TIME_WAIT")
+		flowEndTime = uint32(10)
+		flowEndReason = registry.EndOfFlowReason
+		tcpState = "TIME_WAIT"
 	}
 	tmpElement, _ := registry.GetInfoElement("flowEndSeconds", registry.IANAEnterpriseID)
-	ie10 := entities.NewInfoElementWithValue(tmpElement, flowEndTime)
+	ie10 := entities.NewDateTimeSecondsInfoElement(tmpElement, flowEndTime)
 	if !isIntraNode {
-		antreaFlowType, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.FlowTypeInterNode)
+		antreaFlowType = registry.FlowTypeInterNode
 	} else {
-		antreaFlowType, _ = entities.EncodeToIEDataType(entities.Unsigned8, registry.FlowTypeIntraNode)
+		antreaFlowType = registry.FlowTypeIntraNode
 	}
-	ie11 = entities.NewInfoElementWithValue(entities.NewInfoElement("flowType", 137, 1, registry.AntreaEnterpriseID, 1), antreaFlowType)
+	ie11 = entities.NewUnsigned8InfoElement(entities.NewInfoElement("flowType", 137, 1, registry.AntreaEnterpriseID, 1), antreaFlowType)
 	tmpElement, _ = registry.GetInfoElement("flowEndReason", registry.IANAEnterpriseID)
-	ie12 := entities.NewInfoElementWithValue(tmpElement, flowEndReason)
+	ie12 := entities.NewUnsigned8InfoElement(tmpElement, flowEndReason)
 	tmpElement, _ = registry.GetInfoElement("tcpState", registry.AntreaEnterpriseID)
-	ie13 := entities.NewInfoElementWithValue(tmpElement, tcpState)
-	ie14 := entities.NewInfoElementWithValue(entities.NewInfoElement("ingressNetworkPolicyRuleAction", 139, 1, registry.AntreaEnterpriseID, 1), ingressNetworkPolicyRuleAction)
-	ie15 := entities.NewInfoElementWithValue(entities.NewInfoElement("egressNetworkPolicyRuleAction", 140, 1, registry.AntreaEnterpriseID, 1), egressNetworkPolicyRuleAction)
-	ie16 := entities.NewInfoElementWithValue(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), ingressNetworkPolicyRulePriority)
+	ie13 := entities.NewStringInfoElement(tmpElement, tcpState)
+	ie14 := entities.NewUnsigned8InfoElement(entities.NewInfoElement("ingressNetworkPolicyRuleAction", 139, 1, registry.AntreaEnterpriseID, 1), ingressNetworkPolicyRuleAction)
+	ie15 := entities.NewUnsigned8InfoElement(entities.NewInfoElement("egressNetworkPolicyRuleAction", 140, 1, registry.AntreaEnterpriseID, 1), egressNetworkPolicyRuleAction)
+	ie16 := entities.NewSigned32InfoElement(entities.NewInfoElement("ingressNetworkPolicyRulePriority", 116, 7, registry.AntreaEnterpriseID, 4), ingressNetworkPolicyRulePriority)
 
 	elements = append(elements, ie1, ie2, ie3, ie4, ie5, ie6, ie7, ie8, ie9, ie10, ie11, ie12, ie13, ie14, ie15, ie16)
 	// Add all elements in statsElements.
@@ -335,23 +321,21 @@ func createDataMsgForDst(t *testing.T, isIPv6 bool, isIntraNode bool, isUpdatedR
 		} else {
 			e, _ = registry.GetInfoElement(element, registry.IANAReversedEnterpriseID)
 		}
-		ieWithValue := entities.NewInfoElementWithValue(e, nil)
-		var value []byte
+		var ieWithValue entities.InfoElementWithValue
 		switch element {
 		case "packetTotalCount", "reversePacketTotalCount":
 			if !isUpdatedRecord {
-				value, _ = entities.EncodeToIEDataType(entities.Unsigned64, uint64(502))
+				ieWithValue = entities.NewUnsigned64InfoElement(e, uint64(502))
 			} else {
-				value, _ = entities.EncodeToIEDataType(entities.Unsigned64, uint64(1005))
+				ieWithValue = entities.NewUnsigned64InfoElement(e, uint64(1005))
 			}
 		case "packetDeltaCount", "reversePacketDeltaCount":
 			if !isUpdatedRecord {
-				value, _ = entities.EncodeToIEDataType(entities.Unsigned64, uint64(0))
+				ieWithValue = entities.NewUnsigned64InfoElement(e, uint64(0))
 			} else {
-				value, _ = entities.EncodeToIEDataType(entities.Unsigned64, uint64(503))
+				ieWithValue = entities.NewUnsigned64InfoElement(e, uint64(503))
 			}
 		}
-		ieWithValue.Value = value
 		elements = append(elements, ieWithValue)
 	}
 	err := set.AddRecord(elements, 256)
@@ -429,7 +413,8 @@ func TestAggregateMsgByFlowKey(t *testing.T) {
 	assert.NotNil(t, item)
 	ieWithValue, _, exist := aggRecord.Record.GetInfoElementWithValue("sourceIPv4Address")
 	assert.Equal(t, true, exist)
-	assert.Equal(t, net.IP{0xa, 0x0, 0x0, 0x1}, ieWithValue.Value)
+	ipVal, _ := ieWithValue.GetIPAddressValue()
+	assert.Equal(t, net.IP{0xa, 0x0, 0x0, 0x1}, ipVal)
 	assert.Equal(t, message.GetSet().GetRecords()[0], aggRecord.Record)
 
 	// Template records with IPv6 fields should be ignored
@@ -450,17 +435,16 @@ func TestAggregateMsgByFlowKey(t *testing.T) {
 	aggRecord = aggregationProcess.flowKeyRecordMap[flowKey]
 	ieWithValue, _, exist = aggRecord.Record.GetInfoElementWithValue("sourceIPv6Address")
 	assert.Equal(t, true, exist)
-	assert.Equal(t, net.IP{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}, ieWithValue.Value)
+	ipVal, _ = ieWithValue.GetIPAddressValue()
+	assert.Equal(t, net.IP{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xdf, 0xe1, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xfe, 0xfb}, ipVal)
 	assert.Equal(t, message.GetSet().GetRecords()[0], aggRecord.Record)
 
 	// Test data record with invalid "flowEndSeconds" field
-	element, index, exists := message.GetSet().GetRecords()[0].GetInfoElementWithValue("flowEndSeconds")
+	element, _, exists := message.GetSet().GetRecords()[0].GetInfoElementWithValue("flowEndSeconds")
 	assert.True(t, exists)
-	element.Value = nil
-	err = message.GetSet().GetRecords()[0].SetInfoElementWithValue(index, *element)
-	assert.NoError(t, err)
+	element.ResetValue()
 	err = aggregationProcess.AggregateMsgByFlowKey(message)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAggregationProcess(t *testing.T) {
@@ -843,28 +827,38 @@ func runCorrelationAndCheckResult(t *testing.T, ap *AggregationProcess, record1,
 	if !isIntraNode && !needsCorrleation {
 		// for inter-Node deny connections, either src or dst Pod info will be resolved.
 		sourcePodName, _, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
+		srcPod, _ := sourcePodName.GetStringValue()
 		destinationPodName, _, _ := aggRecord.Record.GetInfoElementWithValue("destinationPodName")
-		assert.True(t, sourcePodName.Value == "" || destinationPodName.Value == "")
+		dstPod, _ := destinationPodName.GetStringValue()
+		assert.True(t, srcPod == "" || dstPod == "")
 		egress, _, _ := aggRecord.Record.GetInfoElementWithValue("egressNetworkPolicyRuleAction")
+		egressVal, _ := egress.GetUnsigned8Value()
 		ingress, _, _ := aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRuleAction")
-		assert.True(t, egress.Value != 0 || ingress.Value != 0)
+		ingressVal, _ := ingress.GetUnsigned8Value()
+		assert.True(t, egressVal != 0 || ingressVal != 0)
 		assert.False(t, ap.AreCorrelatedFieldsFilled(*aggRecord))
 	} else {
 		ieWithValue, _, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
-		assert.Equal(t, "pod1", ieWithValue.Value)
+		pn, _ := ieWithValue.GetStringValue()
+		assert.Equal(t, "pod1", pn)
 		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationPodName")
-		assert.Equal(t, "pod2", ieWithValue.Value)
+		pn, _ = ieWithValue.GetStringValue()
+		assert.Equal(t, "pod2", pn)
 		if !isIPv6 {
 			ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv4")
-			assert.Equal(t, net.ParseIP("192.168.0.1").To4(), ieWithValue.Value)
+			pIP, _ := ieWithValue.GetIPAddressValue()
+			assert.Equal(t, net.ParseIP("192.168.0.1").To4(), pIP)
 		} else {
 			ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv6")
-			assert.Equal(t, net.ParseIP("2001:0:3238:BBBB:63::AAAA"), ieWithValue.Value)
+			pIP, _ := ieWithValue.GetIPAddressValue()
+			assert.Equal(t, net.ParseIP("2001:0:3238:BBBB:63::AAAA"), pIP)
 		}
 		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationServicePort")
-		assert.Equal(t, uint16(4739), ieWithValue.Value)
+		portVal, _ := ieWithValue.GetUnsigned16Value()
+		assert.Equal(t, uint16(4739), portVal)
 		ingressPriority, _, _ := aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRulePriority")
-		assert.Equal(t, ingressPriority.Value, int32(50000))
+		ingressPriorityVal, _ := ingressPriority.GetSigned32Value()
+		assert.Equal(t, ingressPriorityVal, int32(50000))
 		assert.True(t, ap.AreCorrelatedFieldsFilled(*aggRecord))
 	}
 }
@@ -897,38 +891,63 @@ func runAggregationAndCheckResult(t *testing.T, ap *AggregationProcess, srcRecor
 		assert.NotEqual(t, oldInactiveExpiryTime, item.inactiveExpireTime)
 	}
 	ieWithValue, _, _ := aggRecord.Record.GetInfoElementWithValue("sourcePodName")
-	assert.Equal(t, "pod1", ieWithValue.Value)
+	pn, _ := ieWithValue.GetStringValue()
+	assert.Equal(t, "pod1", pn)
 	ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationPodName")
-	assert.Equal(t, "pod2", ieWithValue.Value)
+	pn, _ = ieWithValue.GetStringValue()
+	assert.Equal(t, "pod2", pn)
 	ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationClusterIPv4")
-	assert.Equal(t, net.ParseIP("192.168.0.1").To4(), ieWithValue.Value)
+	pIP, _ := ieWithValue.GetIPAddressValue()
+	assert.Equal(t, net.ParseIP("192.168.0.1").To4(), pIP)
 	ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("destinationServicePort")
-	assert.Equal(t, uint16(4739), ieWithValue.Value)
+	svcPort, _ := ieWithValue.GetUnsigned16Value()
+	assert.Equal(t, uint16(4739), svcPort)
 	ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue("ingressNetworkPolicyRuleAction")
-	assert.Equal(t, registry.NetworkPolicyRuleActionNoAction, ieWithValue.Value)
+	ingressAction, _ := ieWithValue.GetUnsigned8Value()
+	assert.Equal(t, registry.NetworkPolicyRuleActionNoAction, ingressAction)
 	for _, e := range nonStatsElementList {
 		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue(e)
 		expectedIE, _, _ := dstRecordLatest.GetInfoElementWithValue(e)
-		assert.Equal(t, expectedIE.Value, ieWithValue.Value)
+		switch ieWithValue.GetInfoElement().DataType {
+		case entities.Unsigned8:
+			currentVal, _ := ieWithValue.GetUnsigned8Value()
+			expectedVal, _ := expectedIE.GetUnsigned8Value()
+			assert.Equal(t, currentVal, expectedVal)
+		case entities.String:
+			currentVal, _ := ieWithValue.GetStringValue()
+			expectedVal, _ := expectedIE.GetStringValue()
+			assert.Equal(t, currentVal, expectedVal)
+		case entities.Signed32:
+			currentVal, _ := ieWithValue.GetSigned32Value()
+			expectedVal, _ := expectedIE.GetSigned32Value()
+			assert.Equal(t, currentVal, expectedVal)
+		}
 	}
 	for _, e := range statsElementList {
 		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue(e)
+		aggVal, _ := ieWithValue.GetUnsigned64Value()
 		latestRecord, _, _ := dstRecordLatest.GetInfoElementWithValue(e)
+		latestVal, _ := latestRecord.GetUnsigned64Value()
 		if !strings.Contains(e, "Delta") {
-			assert.Equalf(t, latestRecord.Value, ieWithValue.Value, "values should be equal for element %v", e)
+			assert.Equalf(t, latestVal, aggVal, "values should be equal for element %v", e)
 		} else {
 			prevRecord, _, _ := srcRecordLatest.GetInfoElementWithValue(e)
-			assert.Equalf(t, prevRecord.Value.(uint64)+latestRecord.Value.(uint64), ieWithValue.Value, "values should be equal for element %v", e)
+			prevVal, _ := prevRecord.GetUnsigned64Value()
+			assert.Equalf(t, prevVal+latestVal, aggVal, "values should be equal for element %v", e)
 		}
 	}
 	for i, e := range antreaSourceStatsElementList {
 		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue(e)
+		aggVal, _ := ieWithValue.GetUnsigned64Value()
 		latestRecord, _, _ := srcRecordLatest.GetInfoElementWithValue(statsElementList[i])
-		assert.Equalf(t, latestRecord.Value, ieWithValue.Value, "values should be equal for element %v", e)
+		latestVal, _ := latestRecord.GetUnsigned64Value()
+		assert.Equalf(t, latestVal, aggVal, "values should be equal for element %v", e)
 	}
 	for i, e := range antreaDestinationStatsElementList {
 		ieWithValue, _, _ = aggRecord.Record.GetInfoElementWithValue(e)
+		aggVal, _ := ieWithValue.GetUnsigned64Value()
 		latestRecord, _, _ := dstRecordLatest.GetInfoElementWithValue(statsElementList[i])
-		assert.Equalf(t, latestRecord.Value, ieWithValue.Value, "values should be equal for element %v", e)
+		latestVal, _ := latestRecord.GetUnsigned64Value()
+		assert.Equalf(t, latestVal, aggVal, "values should be equal for element %v", e)
 	}
 }

--- a/pkg/kafka/producer/convertor/test/flowtype1.go
+++ b/pkg/kafka/producer/convertor/test/flowtype1.go
@@ -66,74 +66,89 @@ func (c *convertRecordToFlowType1) ConvertIPFIXRecordToFlowMsg(record entities.R
 
 func addAllFieldsToFlowType1(flowMsg *protobuf.FlowType1, record entities.Record) {
 	for _, ie := range record.GetOrderedElementList() {
-		switch ie.Element.Name {
+		var err error
+		var ipVal net.IP
+		var portVal uint16
+		var protoVal uint8
+		element := ie.GetInfoElement()
+		switch element.Name {
 		case "flowStartSeconds":
-			flowMsg.TimeFlowStartInSecs = ie.Value.(uint32)
+			flowMsg.TimeFlowStartInSecs, err = ie.GetUnsigned32Value()
 		case "flowEndSeconds":
-			flowMsg.TimeFlowEndInSecs = ie.Value.(uint32)
+			flowMsg.TimeFlowEndInSecs, err = ie.GetUnsigned32Value()
 		case "sourceIPv4Address", "sourceIPv6Address":
 			if flowMsg.SrcIP != "" {
 				klog.Warningf("Do not expect source IP: %v to be filled already", flowMsg.SrcIP)
 			}
-			flowMsg.SrcIP = ie.Value.(net.IP).String()
+			ipVal, err = ie.GetIPAddressValue()
+			flowMsg.SrcIP = ipVal.String()
 		case "destinationIPv4Address", "destinationIPv6Address":
 			if flowMsg.DstIP != "" {
 				klog.Warningf("Do not expect destination IP: %v to be filled already", flowMsg.DstIP)
 			}
-			flowMsg.DstIP = ie.Value.(net.IP).String()
+			ipVal, err = ie.GetIPAddressValue()
+			flowMsg.DstIP = ipVal.String()
 		case "sourceTransportPort":
-			flowMsg.SrcPort = uint32(ie.Value.(uint16))
+			portVal, err = ie.GetUnsigned16Value()
+			flowMsg.SrcPort = uint32(portVal)
 		case "destinationTransportPort":
-			flowMsg.DstPort = uint32(ie.Value.(uint16))
+			portVal, err = ie.GetUnsigned16Value()
+			flowMsg.DstPort = uint32(portVal)
 		case "protocolIdentifier":
-			flowMsg.Proto = uint32(ie.Value.(uint8))
+			protoVal, err = ie.GetUnsigned8Value()
+			flowMsg.Proto = uint32(protoVal)
 		case "packetTotalCount":
-			flowMsg.PacketsTotal = ie.Value.(uint64)
+			flowMsg.PacketsTotal, err = ie.GetUnsigned64Value()
 		case "octetTotalCount":
-			flowMsg.BytesTotal = ie.Value.(uint64)
+			flowMsg.BytesTotal, err = ie.GetUnsigned64Value()
 		case "packetDeltaCount":
-			flowMsg.PacketsDelta = ie.Value.(uint64)
+			flowMsg.PacketsDelta, err = ie.GetUnsigned64Value()
 		case "octetDeltaCount":
-			flowMsg.BytesDelta = ie.Value.(uint64)
+			flowMsg.BytesDelta, err = ie.GetUnsigned64Value()
 		case "reversePacketTotalCount":
-			flowMsg.ReversePacketsTotal = ie.Value.(uint64)
+			flowMsg.ReversePacketsTotal, err = ie.GetUnsigned64Value()
 		case "reverseOctetTotalCount":
-			flowMsg.ReverseBytesTotal = ie.Value.(uint64)
+			flowMsg.ReverseBytesTotal, err = ie.GetUnsigned64Value()
 		case "reversePacketDeltaCount":
-			flowMsg.ReversePacketsDelta = ie.Value.(uint64)
+			flowMsg.ReversePacketsDelta, err = ie.GetUnsigned64Value()
 		case "reverseOctetDeltaCount":
-			flowMsg.ReverseBytesDelta = ie.Value.(uint64)
+			flowMsg.ReverseBytesDelta, err = ie.GetUnsigned64Value()
 		case "sourcePodNamespace":
-			flowMsg.SrcPodNamespace = ie.Value.(string)
+			flowMsg.SrcPodNamespace, err = ie.GetStringValue()
 		case "sourcePodName":
-			flowMsg.SrcPodName = ie.Value.(string)
+			flowMsg.SrcPodName, err = ie.GetStringValue()
 		case "sourceNodeName":
-			flowMsg.SrcNodeName = ie.Value.(string)
+			flowMsg.SrcNodeName, err = ie.GetStringValue()
 		case "destinationPodNamespace":
-			flowMsg.DstPodNamespace = ie.Value.(string)
+			flowMsg.DstPodNamespace, err = ie.GetStringValue()
 		case "destinationPodName":
-			flowMsg.DstPodName = ie.Value.(string)
+			flowMsg.DstPodName, err = ie.GetStringValue()
 		case "destinationNodeName":
-			flowMsg.DstNodeName = ie.Value.(string)
+			flowMsg.DstNodeName, err = ie.GetStringValue()
 		case "destinationClusterIPv4", "destinationClusterIPv6":
 			if flowMsg.DstClusterIP != "" {
 				klog.Warningf("Do not expect destination cluster IP: %v to be filled already", flowMsg.DstClusterIP)
 			}
-			flowMsg.DstClusterIP = ie.Value.(net.IP).String()
+			ipVal, err = ie.GetIPAddressValue()
+			flowMsg.DstClusterIP = ipVal.String()
 		case "destinationServicePort":
-			flowMsg.DstServicePort = uint32(ie.Value.(uint16))
+			portVal, err = ie.GetUnsigned16Value()
+			flowMsg.DstServicePort = uint32(portVal)
 		case "destinationServicePortName":
-			flowMsg.DstServicePortName = ie.Value.(string)
+			flowMsg.DstServicePortName, err = ie.GetStringValue()
 		case "ingressNetworkPolicyName":
-			flowMsg.IngressPolicyName = ie.Value.(string)
+			flowMsg.IngressPolicyName, err = ie.GetStringValue()
 		case "ingressNetworkPolicyNamespace":
-			flowMsg.IngressPolicyNamespace = ie.Value.(string)
+			flowMsg.IngressPolicyNamespace, err = ie.GetStringValue()
 		case "egressNetworkPolicyName":
-			flowMsg.EgressPolicyName = ie.Value.(string)
+			flowMsg.EgressPolicyName, err = ie.GetStringValue()
 		case "egressNetworkPolicyNamespace":
-			flowMsg.EgressPolicyNamespace = ie.Value.(string)
+			flowMsg.EgressPolicyNamespace, err = ie.GetStringValue()
 		default:
-			klog.Warningf("There is no field with name: %v in flow message (.proto schema)", ie.Element.Name)
+			klog.Warningf("There is no field with name: %v in flow message (.proto schema)", element.Name)
+		}
+		if err != nil {
+			klog.Errorf("Value format is different from expected in info element: %v", ie)
 		}
 	}
 }

--- a/pkg/kafka/producer/convertor/test/flowtype2.go
+++ b/pkg/kafka/producer/convertor/test/flowtype2.go
@@ -65,74 +65,89 @@ func (c *convertRecordToFlowType2) ConvertIPFIXRecordToFlowMsg(record entities.R
 
 func addAllFieldsToFlowType2(flowMsg *protobuf.FlowType2, record entities.Record) {
 	for _, ie := range record.GetOrderedElementList() {
-		switch ie.Element.Name {
+		var err error
+		var ipVal net.IP
+		var portVal uint16
+		var protoVal uint8
+		element := ie.GetInfoElement()
+		switch element.Name {
 		case "flowStartSeconds":
-			flowMsg.TimeFlowStartInSecs = ie.Value.(uint32)
+			flowMsg.TimeFlowStartInSecs, err = ie.GetUnsigned32Value()
 		case "flowEndSeconds":
-			flowMsg.TimeFlowEndInSecs = ie.Value.(uint32)
+			flowMsg.TimeFlowEndInSecs, err = ie.GetUnsigned32Value()
 		case "sourceIPv4Address", "sourceIPv6Address":
 			if flowMsg.SrcIP != "" {
 				klog.Warningf("Do not expect source IP: %v to be filled already", flowMsg.SrcIP)
 			}
-			flowMsg.SrcIP = ie.Value.(net.IP).String()
+			ipVal, err = ie.GetIPAddressValue()
+			flowMsg.SrcIP = ipVal.String()
 		case "destinationIPv4Address", "destinationIPv6Address":
 			if flowMsg.DstIP != "" {
 				klog.Warningf("Do not expect destination IP: %v to be filled already", flowMsg.DstIP)
 			}
-			flowMsg.DstIP = ie.Value.(net.IP).String()
+			ipVal, err = ie.GetIPAddressValue()
+			flowMsg.DstIP = ipVal.String()
 		case "sourceTransportPort":
-			flowMsg.SrcPort = uint32(ie.Value.(uint16))
+			portVal, err = ie.GetUnsigned16Value()
+			flowMsg.SrcPort = uint32(portVal)
 		case "destinationTransportPort":
-			flowMsg.DstPort = uint32(ie.Value.(uint16))
+			portVal, err = ie.GetUnsigned16Value()
+			flowMsg.DstPort = uint32(portVal)
 		case "protocolIdentifier":
-			flowMsg.Proto = uint32(ie.Value.(uint8))
+			protoVal, err = ie.GetUnsigned8Value()
+			flowMsg.Proto = uint32(protoVal)
 		case "packetTotalCount":
-			flowMsg.PacketsTotal = ie.Value.(uint64)
+			flowMsg.PacketsTotal, err = ie.GetUnsigned64Value()
 		case "octetTotalCount":
-			flowMsg.BytesTotal = ie.Value.(uint64)
+			flowMsg.BytesTotal, err = ie.GetUnsigned64Value()
 		case "packetDeltaCount":
-			flowMsg.PacketsDelta = ie.Value.(uint64)
+			flowMsg.PacketsDelta, err = ie.GetUnsigned64Value()
 		case "octetDeltaCount":
-			flowMsg.BytesDelta = ie.Value.(uint64)
+			flowMsg.BytesDelta, err = ie.GetUnsigned64Value()
 		case "reversePacketTotalCount":
-			flowMsg.ReversePacketsTotal = ie.Value.(uint64)
+			flowMsg.ReversePacketsTotal, err = ie.GetUnsigned64Value()
 		case "reverseOctetTotalCount":
-			flowMsg.ReverseBytesTotal = ie.Value.(uint64)
+			flowMsg.ReverseBytesTotal, err = ie.GetUnsigned64Value()
 		case "reversePacketDeltaCount":
-			flowMsg.ReversePacketsDelta = ie.Value.(uint64)
+			flowMsg.ReversePacketsDelta, err = ie.GetUnsigned64Value()
 		case "reverseOctetDeltaCount":
-			flowMsg.ReverseBytesDelta = ie.Value.(uint64)
+			flowMsg.ReverseBytesDelta, err = ie.GetUnsigned64Value()
 		case "sourcePodNamespace":
-			flowMsg.SrcPodNamespace = ie.Value.(string)
+			flowMsg.SrcPodNamespace, err = ie.GetStringValue()
 		case "sourcePodName":
-			flowMsg.SrcPodName = ie.Value.(string)
+			flowMsg.SrcPodName, err = ie.GetStringValue()
 		case "sourceNodeName":
-			flowMsg.SrcNodeName = ie.Value.(string)
+			flowMsg.SrcNodeName, err = ie.GetStringValue()
 		case "destinationPodNamespace":
-			flowMsg.DstPodNamespace = ie.Value.(string)
+			flowMsg.DstPodNamespace, err = ie.GetStringValue()
 		case "destinationPodName":
-			flowMsg.DstPodName = ie.Value.(string)
+			flowMsg.DstPodName, err = ie.GetStringValue()
 		case "destinationNodeName":
-			flowMsg.DstNodeName = ie.Value.(string)
+			flowMsg.DstNodeName, err = ie.GetStringValue()
 		case "destinationClusterIPv4", "destinationClusterIPv6":
 			if flowMsg.DstClusterIP != "" {
 				klog.Warningf("Do not expect destination cluster IP: %v to be filled already", flowMsg.DstClusterIP)
 			}
-			flowMsg.DstClusterIP = ie.Value.(net.IP).String()
+			ipVal, err = ie.GetIPAddressValue()
+			flowMsg.DstClusterIP = ipVal.String()
 		case "destinationServicePort":
-			flowMsg.DstServicePort = uint32(ie.Value.(uint16))
+			portVal, err = ie.GetUnsigned16Value()
+			flowMsg.DstServicePort = uint32(portVal)
 		case "destinationServicePortName":
-			flowMsg.DstServicePortName = ie.Value.(string)
+			flowMsg.DstServicePortName, err = ie.GetStringValue()
 		case "ingressNetworkPolicyName":
-			flowMsg.IngressPolicyName = ie.Value.(string)
+			flowMsg.IngressPolicyName, err = ie.GetStringValue()
 		case "ingressNetworkPolicyNamespace":
-			flowMsg.IngressPolicyNamespace = ie.Value.(string)
+			flowMsg.IngressPolicyNamespace, err = ie.GetStringValue()
 		case "egressNetworkPolicyName":
-			flowMsg.EgressPolicyName = ie.Value.(string)
+			flowMsg.EgressPolicyName, err = ie.GetStringValue()
 		case "egressNetworkPolicyNamespace":
-			flowMsg.EgressPolicyNamespace = ie.Value.(string)
+			flowMsg.EgressPolicyNamespace, err = ie.GetStringValue()
 		default:
-			klog.Warningf("There is no field with name: %v in flow message (.proto schema)", ie.Element.Name)
+			klog.Warningf("There is no field with name: %v in flow message (.proto schema)", element.Name)
+		}
+		if err != nil {
+			klog.Errorf("Value format is different from expected in info element: %v", ie)
 		}
 	}
 }

--- a/pkg/kafka/producer/convertor/test/flowtype_test.go
+++ b/pkg/kafka/producer/convertor/test/flowtype_test.go
@@ -95,7 +95,7 @@ func createMsgwithDataSet(t *testing.T, isV6 bool) *entities.Message {
 		if err != nil {
 			t.Fatalf("Error when fetching element with name %v: %v", ieName, err)
 		}
-		ieWithValue := entities.NewInfoElementWithValue(ie, nil)
+
 		var value []byte
 		switch ieName {
 		case "flowStartSeconds", "flowEndSeconds":
@@ -120,7 +120,7 @@ func createMsgwithDataSet(t *testing.T, isV6 bool) *entities.Message {
 		default:
 			t.Fatalf("information element with name: %v is not present in the element list", ieName)
 		}
-		ieWithValue.Value = value
+		ieWithValue, _ := entities.DecodeAndCreateInfoElementWithValue(ie, value)
 		elements = append(elements, ieWithValue)
 	}
 
@@ -129,7 +129,6 @@ func createMsgwithDataSet(t *testing.T, isV6 bool) *entities.Message {
 		if err != nil {
 			t.Fatalf("Error when fetching element with name %v: %v", ieName, err)
 		}
-		ieWithValue := entities.NewInfoElementWithValue(ie, nil)
 		var value []byte
 		switch ieName {
 		case "reversePacketTotalCount", "reverseOctetTotalCount", "reversePacketDeltaCount", "reverseOctetDeltaCount":
@@ -137,7 +136,7 @@ func createMsgwithDataSet(t *testing.T, isV6 bool) *entities.Message {
 		default:
 			t.Fatalf("information element with name: %v is not present in the element list", ieName)
 		}
-		ieWithValue.Value = value
+		ieWithValue, _ := entities.DecodeAndCreateInfoElementWithValue(ie, value)
 		elements = append(elements, ieWithValue)
 	}
 
@@ -146,7 +145,6 @@ func createMsgwithDataSet(t *testing.T, isV6 bool) *entities.Message {
 		if err != nil {
 			t.Fatalf("Error when fetching element with name %v: %v", ieName, err)
 		}
-		ieWithValue := entities.NewInfoElementWithValue(ie, nil)
 		var value []byte
 		switch ieName {
 		case "sourcePodNamespace":
@@ -174,7 +172,7 @@ func createMsgwithDataSet(t *testing.T, isV6 bool) *entities.Message {
 		default:
 			t.Fatalf("information element with name: %v is not present in the element list", ieName)
 		}
-		ieWithValue.Value = value
+		ieWithValue, _ := entities.DecodeAndCreateInfoElementWithValue(ie, value)
 		elements = append(elements, ieWithValue)
 	}
 	if err := set.AddRecord(elements, 256); err != nil {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -67,9 +67,9 @@ const (
 )
 
 var (
-	// globalRegistryByID shows mapping EnterpriseID -> Info Element ID -> Info Element
+	// globalRegistryByID shows mapping EnterpriseID -> Info element ID -> Info element
 	globalRegistryByID map[uint32]map[uint16]*entities.InfoElement
-	// globalRegistryByName shows mapping EnterpriseID -> Info Element name -> Info Element
+	// globalRegistryByName shows mapping EnterpriseID -> Info element name -> Info element
 	globalRegistryByName map[uint32]map[string]*entities.InfoElement
 )
 
@@ -93,7 +93,7 @@ func GetInfoElementFromID(elementID uint16, enterpriseID uint32) (*entities.Info
 		return nil, fmt.Errorf("Registry with EnterpriseID %d is not supported.", enterpriseID)
 	}
 	if element, exist := globalRegistryByID[enterpriseID][elementID]; !exist {
-		return element, fmt.Errorf("Information Element with elementID %d in registry with enterpriseID %d cannot be found.", elementID, enterpriseID)
+		return element, fmt.Errorf("Information element with elementID %d in registry with enterpriseID %d cannot be found.", elementID, enterpriseID)
 	} else {
 		return element, nil
 	}
@@ -104,7 +104,7 @@ func GetInfoElement(name string, enterpriseID uint32) (*entities.InfoElement, er
 		return nil, fmt.Errorf("Registry with EnterpriseID %d is not supported.", enterpriseID)
 	}
 	if element, exist := globalRegistryByName[enterpriseID][name]; !exist {
-		return element, fmt.Errorf("Information Element with name %s in registry with enterpriseID %d cannot be found.", name, enterpriseID)
+		return element, fmt.Errorf("Information element with name %s in registry with enterpriseID %d cannot be found.", name, enterpriseID)
 	} else {
 		return element, nil
 	}

--- a/pkg/test/collector_intermediate_test.go
+++ b/pkg/test/collector_intermediate_test.go
@@ -173,50 +173,70 @@ func testCollectorToIntermediate(t *testing.T, address net.Addr, isIPv6 bool) {
 	}
 	assert.Equal(t, 25, len(record.GetOrderedElementList()))
 	for _, element := range record.GetOrderedElementList() {
-		switch element.Element.Name {
+		infoElem := element.GetInfoElement()
+		switch infoElem.Name {
 		case "sourcePodName":
-			assert.Equal(t, "pod1", element.Value)
+			val, _ := element.GetStringValue()
+			assert.Equal(t, "pod1", val)
 		case "destinationPodName":
-			assert.Equal(t, "pod2", element.Value)
+			val, _ := element.GetStringValue()
+			assert.Equal(t, "pod2", val)
 		case "flowEndSeconds":
-			assert.Equal(t, uint32(1257896000), element.Value)
+			val, _ := element.GetUnsigned32Value()
+			assert.Equal(t, uint32(1257896000), val)
 		case "flowEndReason":
-			assert.Equal(t, registry.ActiveTimeoutReason, element.Value)
+			val, _ := element.GetUnsigned8Value()
+			assert.Equal(t, registry.ActiveTimeoutReason, val)
 		case "tcpState":
-			assert.Equal(t, "ESTABLISHED", element.Value)
-		case "packetTotalCount":
-			assert.Equal(t, uint64(1000), element.Value)
+			val, _ := element.GetStringValue()
+			assert.Equal(t, "ESTABLISHED", val)
 		case "packetDeltaCount":
-			assert.Equal(t, uint64(1000), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(1000), val)
+		case "packetTotalCount":
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(1000), val)
 		case "destinationClusterIPv4":
-			assert.Equal(t, net.IP{10, 0, 0, 3}, element.Value)
+			val, _ := element.GetIPAddressValue()
+			assert.Equal(t, net.IP{10, 0, 0, 3}, val)
 		case "destinationClusterIPv6":
-			assert.Equal(t, net.IP{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xbb, 0xbb, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xaa, 0xaa}, element.Value)
+			val, _ := element.GetIPAddressValue()
+			assert.Equal(t, net.IP{0x20, 0x1, 0x0, 0x0, 0x32, 0x38, 0xbb, 0xbb, 0x0, 0x63, 0x0, 0x0, 0x0, 0x0, 0xaa, 0xaa}, val)
 		case "destinationServicePort":
-			assert.Equal(t, uint16(4739), element.Value)
+			val, _ := element.GetUnsigned16Value()
+			assert.Equal(t, uint16(4739), val)
 		case "reversePacketDeltaCount":
-			assert.Equal(t, uint64(350), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(350), val)
 		case "reversePacketTotalCount":
-			assert.Equal(t, uint64(400), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(400), val)
 		case "packetTotalCountFromSourceNode":
-			assert.Equal(t, uint64(800), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(800), val)
 		case "packetDeltaCountFromSourceNode":
-			assert.Equal(t, uint64(500), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(500), val)
 		case "packetTotalCountFromDestinationNode":
-			assert.Equal(t, uint64(1000), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(1000), val)
 		case "packetDeltaCountFromDestinationNode":
-			assert.Equal(t, uint64(500), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(500), val)
 		case "reversePacketTotalCountFromSourceNode":
-			assert.Equal(t, uint64(300), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(300), val)
 		case "reversePacketDeltaCountFromSourceNode":
-			assert.Equal(t, uint64(150), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(150), val)
 		case "reversePacketTotalCountFromDestinationNode":
-			assert.Equal(t, uint64(400), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(400), val)
 		case "reversePacketDeltaCountFromDestinationNode":
-			assert.Equal(t, uint64(200), element.Value)
+			val, _ := element.GetUnsigned64Value()
+			assert.Equal(t, uint64(200), val)
 		}
 	}
-
 }
 
 func copyFlowKeyRecordMap(key intermediate.FlowKey, aggregationFlowRecord *intermediate.AggregationFlowRecord) error {
@@ -244,8 +264,10 @@ func waitForAggregationToFinish(t *testing.T, ap *intermediate.AggregationProces
 		ap.ForAllRecordsDo(copyFlowKeyRecordMap)
 		if len(flowKeyRecordMap) > 0 {
 			ie1, _, _ := flowKeyRecordMap[key].Record.GetInfoElementWithValue("sourcePodName")
+			ie1Val, _ := ie1.GetStringValue()
 			ie2, _, _ := flowKeyRecordMap[key].Record.GetInfoElementWithValue("destinationPodName")
-			if ie1.Value == "pod1" && ie2.Value == "pod2" {
+			ie2Val, _ := ie2.GetStringValue()
+			if ie1Val == "pod1" && ie2Val == "pod2" {
 				return true, nil
 			} else {
 				return false, nil

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -138,7 +138,7 @@ func createTemplateSet(templateID uint16, isIPv6 bool) entities.Set {
 	ianaFields = append(ianaFields, commonFields...)
 	for _, name := range ianaFields {
 		element, _ := registry.GetInfoElement(name, registry.IANAEnterpriseID)
-		ie := entities.NewInfoElementWithValue(element, nil)
+		ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 		elements = append(elements, ie)
 	}
 	antreaFields := antreaCommonFields
@@ -149,12 +149,12 @@ func createTemplateSet(templateID uint16, isIPv6 bool) entities.Set {
 	}
 	for _, name := range antreaFields {
 		element, _ := registry.GetInfoElement(name, registry.AntreaEnterpriseID)
-		ie := entities.NewInfoElementWithValue(element, nil)
+		ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 		elements = append(elements, ie)
 	}
 	for _, name := range reverseFields {
 		element, _ := registry.GetInfoElement(name, registry.IANAReversedEnterpriseID)
-		ie := entities.NewInfoElementWithValue(element, nil)
+		ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
 		elements = append(elements, ie)
 	}
 	templateSet.AddRecord(elements, templateID)
@@ -167,6 +167,7 @@ func createDataSet(templateID uint16, isSrcNode, isIPv6 bool, isMultipleRecord b
 	elements := getDataRecordElements(isSrcNode, isIPv6)
 	dataSet.AddRecord(elements, templateID)
 	if isMultipleRecord {
+		dataSet.PrepareSet(entities.Data, templateID)
 		elements = getDataRecordElements(isSrcNode, isIPv6)
 		dataSet.AddRecord(elements, templateID)
 	}
@@ -186,23 +187,23 @@ func getDataRecordElements(isSrcNode, isIPv6 bool) []entities.InfoElementWithVal
 		var ie entities.InfoElementWithValue
 		switch name {
 		case "sourceIPv4Address", "sourceIPv6Address":
-			ie = entities.NewInfoElementWithValue(element, testRec.srcIP)
+			ie = entities.NewIPAddressInfoElement(element, testRec.srcIP)
 		case "destinationIPv4Address", "destinationIPv6Address":
-			ie = entities.NewInfoElementWithValue(element, testRec.dstIP)
+			ie = entities.NewIPAddressInfoElement(element, testRec.dstIP)
 		case "sourceTransportPort":
-			ie = entities.NewInfoElementWithValue(element, testRec.srcPort)
+			ie = entities.NewUnsigned16InfoElement(element, testRec.srcPort)
 		case "destinationTransportPort":
-			ie = entities.NewInfoElementWithValue(element, testRec.dstPort)
+			ie = entities.NewUnsigned16InfoElement(element, testRec.dstPort)
 		case "protocolIdentifier":
-			ie = entities.NewInfoElementWithValue(element, testRec.proto)
+			ie = entities.NewUnsigned8InfoElement(element, testRec.proto)
 		case "packetTotalCount":
-			ie = entities.NewInfoElementWithValue(element, testRec.pktCount)
+			ie = entities.NewUnsigned64InfoElement(element, testRec.pktCount)
 		case "packetDeltaCount":
-			ie = entities.NewInfoElementWithValue(element, testRec.pktDelta)
+			ie = entities.NewUnsigned64InfoElement(element, testRec.pktDelta)
 		case "flowEndSeconds":
-			ie = entities.NewInfoElementWithValue(element, testRec.flowEnd)
+			ie = entities.NewDateTimeSecondsInfoElement(element, testRec.flowEnd)
 		case "flowEndReason":
-			ie = entities.NewInfoElementWithValue(element, testRec.flowEndReason)
+			ie = entities.NewUnsigned8InfoElement(element, testRec.flowEndReason)
 		}
 		elements = append(elements, ie)
 	}
@@ -217,17 +218,17 @@ func getDataRecordElements(isSrcNode, isIPv6 bool) []entities.InfoElementWithVal
 		var ie entities.InfoElementWithValue
 		switch name {
 		case "destinationClusterIPv4", "destinationClusterIPv6":
-			ie = entities.NewInfoElementWithValue(element, testRec.dstClusterIP)
+			ie = entities.NewIPAddressInfoElement(element, testRec.dstClusterIP)
 		case "sourcePodName":
-			ie = entities.NewInfoElementWithValue(element, testRec.srcPod)
+			ie = entities.NewStringInfoElement(element, testRec.srcPod)
 		case "destinationPodName":
-			ie = entities.NewInfoElementWithValue(element, testRec.dstPod)
+			ie = entities.NewStringInfoElement(element, testRec.dstPod)
 		case "destinationServicePort":
-			ie = entities.NewInfoElementWithValue(element, testRec.dstSvcPort)
+			ie = entities.NewUnsigned16InfoElement(element, testRec.dstSvcPort)
 		case "flowType":
-			ie = entities.NewInfoElementWithValue(element, testRec.flowType)
+			ie = entities.NewUnsigned8InfoElement(element, testRec.flowType)
 		case "tcpState":
-			ie = entities.NewInfoElementWithValue(element, testRec.tcpState)
+			ie = entities.NewStringInfoElement(element, testRec.tcpState)
 		}
 		elements = append(elements, ie)
 	}
@@ -236,9 +237,9 @@ func getDataRecordElements(isSrcNode, isIPv6 bool) []entities.InfoElementWithVal
 		var ie entities.InfoElementWithValue
 		switch name {
 		case "reversePacketTotalCount":
-			ie = entities.NewInfoElementWithValue(element, testRec.revPktCount)
+			ie = entities.NewUnsigned64InfoElement(element, testRec.revPktCount)
 		case "reversePacketDeltaCount":
-			ie = entities.NewInfoElementWithValue(element, testRec.revPktDelta)
+			ie = entities.NewUnsigned64InfoElement(element, testRec.revPktDelta)
 		}
 		elements = append(elements, ie)
 	}


### PR DESCRIPTION
Instead of relying on the fact that any data type can be interpreted
through interface{} type using their pointer, we move to InfoElementWithValue
interface. For each data type, we implement this interface with a separate struct.

This results in a very big file pkg/entities/ie_value.go
As there is no good support for generic data types in golang, we need to resort to
this.

Fixes one of the tasks in Issue #209 

In the process, we reduced allocations and memory consumed in the performance
test.

Before fix:
```
BenchmarkMultipleExportersToCollector-16    	       1	1392006670 ns/op	347268992 B/op	 5296157 allocs/op
PASS
ok  	github.com/vmware/go-ipfix/pkg/test	1.829s
```
After fix:
```
BenchmarkMultipleExportersToCollector-16    	       1	1346594175 ns/op	237156360 B/op	 4880056 allocs/op
PASS
ok  	github.com/vmware/go-ipfix/pkg/test	1.865s
```