### PR TITLE
Add GetRecords method to AggregationProcess

### DIFF
--- a/pkg/entities/record.go
+++ b/pkg/entities/record.go
@@ -40,6 +40,7 @@ type Record interface {
 	GetInfoElementWithValue(name string) (InfoElementWithValue, int, bool)
 	GetRecordLength() int
 	GetMinDataRecordLen() uint16
+	GetString() string
 }
 
 type baseRecord struct {
@@ -109,6 +110,53 @@ func (b *baseRecord) GetInfoElementWithValue(name string) (InfoElementWithValue,
 		}
 	}
 	return nil, 0, false
+}
+
+func (b *baseRecord) GetString() string {
+	var recordString string
+	for _, ie := range b.GetOrderedElementList() {
+		switch ie.GetDataType() {
+		case Unsigned8:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned8Value())
+		case Unsigned16:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned16Value())
+		case Unsigned32:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned32Value())
+		case Unsigned64:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned64Value())
+		case Signed8:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetSigned8Value())
+		case Signed16:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetSigned16Value())
+		case Signed32:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetSigned32Value())
+		case Signed64:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetSigned64Value())
+		case Float32:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetFloat32Value())
+		case Float64:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetFloat64Value())
+		case Boolean:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetBooleanValue())
+		case DateTimeSeconds:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned32Value())
+		case DateTimeMilliseconds:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned64Value())
+		case DateTimeMicroseconds, DateTimeNanoseconds:
+			err := fmt.Errorf("API does not support micro and nano seconds types yet")
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), err)
+		case MacAddress:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetMacAddressValue())
+		case Ipv4Address, Ipv6Address:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetIPAddressValue())
+		case String:
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetStringValue())
+		default:
+			err := fmt.Errorf("API supports only valid information elements with datatypes given in RFC7011")
+			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), err)
+		}
+	}
+	return recordString
 }
 
 func (d *dataRecord) PrepareRecord() error {

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -147,6 +147,20 @@ func (mr *MockRecordMockRecorder) GetRecordLength() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecordLength", reflect.TypeOf((*MockRecord)(nil).GetRecordLength))
 }
 
+// GetString mocks base method
+func (m *MockRecord) GetString() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetString")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetString indicates an expected call of GetString
+func (mr *MockRecordMockRecorder) GetString() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetString", reflect.TypeOf((*MockRecord)(nil).GetString))
+}
+
 // GetTemplateID mocks base method
 func (m *MockRecord) GetTemplateID() uint16 {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This commit adds GetRecords method to get string format flow records.
It accepts FlowKey to filter the flow records.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>