### PR TITLE
Modify flow visibility methods and return type

### DIFF
--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -137,19 +137,19 @@ func (cp *CollectingProcess) CloseMsgChan() {
 	close(cp.messageChan)
 }
 
-func (cp *CollectingProcess) GetNumOfRecordsReceived() uint64 {
+func (cp *CollectingProcess) GetNumRecordsReceived() int64 {
 	cp.mutex.RLock()
 	defer cp.mutex.RUnlock()
-	return cp.numOfRecordsReceived
+	return int64(cp.numOfRecordsReceived)
 }
 
-func (cp *CollectingProcess) GetNumOfConnToCollector() int {
+func (cp *CollectingProcess) GetNumConnToCollector() int64 {
 	cp.mutex.RLock()
 	defer cp.mutex.RUnlock()
-	return len(cp.clients)
+	return int64(len(cp.clients))
 }
 
-func (cp *CollectingProcess) incrementNumOfRecordsReceived() {
+func (cp *CollectingProcess) incrementNumRecordsReceived() {
 	cp.mutex.Lock()
 	defer cp.mutex.Unlock()
 	cp.numOfRecordsReceived = cp.numOfRecordsReceived + 1
@@ -214,7 +214,7 @@ func (cp *CollectingProcess) decodePacket(packetBuffer *bytes.Buffer, exportAddr
 
 	// the thread(s)/client(s) executing the code will get blocked until the message is consumed/read in other goroutines.
 	cp.messageChan <- message
-	cp.incrementNumOfRecordsReceived()
+	cp.incrementNumRecordsReceived()
 	return message, nil
 }
 

--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -76,7 +76,7 @@ func TestTCPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 	cp.Stop()
 	template, _ := cp.getTemplate(1, 256)
 	assert.NotNil(t, template, "TCP Collecting Process should receive and store the received template.")
-	assert.Equal(t, uint64(1), cp.GetNumOfRecordsReceived())
+	assert.Equal(t, int64(1), cp.GetNumRecordsReceived())
 }
 
 func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
@@ -105,7 +105,7 @@ func TestUDPCollectingProcess_ReceiveTemplateRecord(t *testing.T) {
 	cp.Stop()
 	template, _ := cp.getTemplate(1, 256)
 	assert.NotNil(t, template, "UDP Collecting Process should receive and store the received template.")
-	assert.Equal(t, uint64(1), cp.GetNumOfRecordsReceived())
+	assert.Equal(t, int64(1), cp.GetNumRecordsReceived())
 }
 
 func TestTCPCollectingProcess_ReceiveDataRecord(t *testing.T) {
@@ -141,7 +141,7 @@ func TestTCPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 	// Check if connection has closed properly or not by trying to create a new connection.
 	_, err = net.Dial(collectorAddr.Network(), collectorAddr.String())
 	assert.Error(t, err)
-	assert.Equal(t, uint64(1), cp.GetNumOfRecordsReceived())
+	assert.Equal(t, int64(1), cp.GetNumRecordsReceived())
 }
 
 func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
@@ -179,7 +179,7 @@ func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 	_, err = conn.Write(validDataPacket)
 	assert.Error(t, err)
 	conn.Close()
-	assert.Equal(t, uint64(1), cp.GetNumOfRecordsReceived())
+	assert.Equal(t, int64(1), cp.GetNumRecordsReceived())
 }
 
 func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
@@ -203,7 +203,7 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 			t.Errorf("Cannot establish connection to %s", collectorAddr.String())
 		}
 		time.Sleep(time.Millisecond)
-		assert.GreaterOrEqual(t, cp.GetNumOfConnToCollector(), 2, "There should be at least two tcp clients.")
+		assert.GreaterOrEqual(t, cp.GetNumConnToCollector(), int64(2), "There should be at least two tcp clients.")
 		cp.Stop()
 	}()
 	cp.Start()
@@ -234,7 +234,7 @@ func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {
 	defer conn2.Close()
 	conn2.Write(validTemplatePacket)
 	time.Sleep(time.Millisecond)
-	assert.GreaterOrEqual(t, cp.GetNumOfConnToCollector(), 2, "There should be at least two udp clients.")
+	assert.GreaterOrEqual(t, cp.GetNumConnToCollector(), int64(2), "There should be at least two udp clients.")
 	// there should be two messages received
 	<-cp.GetMsgChan()
 	<-cp.GetMsgChan()

--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -127,11 +127,11 @@ func (a *AggregationProcess) Stop() {
 	a.stopChan <- true
 }
 
-// GetNumberOfFlows returns total number of connections/flows stored in map
-func (a *AggregationProcess) GetNumberOfFlows() uint64 {
+// GetNumFlows returns total number of connections/flows stored in map
+func (a *AggregationProcess) GetNumFlows() int64 {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
-	return uint64(len(a.flowKeyRecordMap))
+	return int64(len(a.flowKeyRecordMap))
 }
 
 // AggregateMsgByFlowKey gets flow key from records in message and stores in cache

--- a/pkg/intermediate/aggregate_test.go
+++ b/pkg/intermediate/aggregate_test.go
@@ -404,7 +404,7 @@ func TestAggregateMsgByFlowKey(t *testing.T) {
 	message = createDataMsgForSrc(t, false, false, false, false, false)
 	err = aggregationProcess.AggregateMsgByFlowKey(message)
 	assert.NoError(t, err)
-	assert.NotZero(t, uint64(1), aggregationProcess.GetNumberOfFlows())
+	assert.NotZero(t, uint64(1), aggregationProcess.GetNumFlows())
 	assert.NotZero(t, aggregationProcess.expirePriorityQueue.Len())
 	flowKey := FlowKey{"10.0.0.1", "10.0.0.2", 6, 1234, 5678}
 	aggRecord := aggregationProcess.flowKeyRecordMap[flowKey]
@@ -421,13 +421,13 @@ func TestAggregateMsgByFlowKey(t *testing.T) {
 	err = aggregationProcess.AggregateMsgByFlowKey(message)
 	assert.NoError(t, err)
 	// It should have only data record with IPv4 fields that is added before.
-	assert.Equal(t, uint64(1), aggregationProcess.GetNumberOfFlows())
+	assert.Equal(t, int64(1), aggregationProcess.GetNumFlows())
 	assert.Equal(t, 1, aggregationProcess.expirePriorityQueue.Len())
 	// Data record with IPv6 addresses should be processed and stored correctly
 	message = createDataMsgForSrc(t, true, false, false, false, false)
 	err = aggregationProcess.AggregateMsgByFlowKey(message)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(2), aggregationProcess.GetNumberOfFlows())
+	assert.Equal(t, int64(2), aggregationProcess.GetNumFlows())
 	assert.Equal(t, 2, aggregationProcess.expirePriorityQueue.Len())
 	flowKey = FlowKey{"2001:0:3238:dfe1:63::fefb", "2001:0:3238:dfe1:63::fefc", 6, 1234, 5678}
 	assert.NotNil(t, aggregationProcess.flowKeyRecordMap[flowKey])
@@ -638,10 +638,10 @@ func TestDeleteFlowKeyFromMapWithLock(t *testing.T) {
 		areExternalFieldsFilled:   false,
 	}
 	aggregationProcess.flowKeyRecordMap[flowKey1] = aggFlowRecord
-	assert.Equal(t, uint64(1), aggregationProcess.GetNumberOfFlows())
+	assert.Equal(t, int64(1), aggregationProcess.GetNumFlows())
 	err := aggregationProcess.deleteFlowKeyFromMap(flowKey2)
 	assert.Error(t, err)
-	assert.Equal(t, uint64(1), aggregationProcess.GetNumberOfFlows())
+	assert.Equal(t, int64(1), aggregationProcess.GetNumFlows())
 	err = aggregationProcess.deleteFlowKeyFromMap(flowKey1)
 	assert.NoError(t, err)
 	assert.Empty(t, aggregationProcess.flowKeyRecordMap)
@@ -909,7 +909,7 @@ func runCorrelationAndCheckResult(t *testing.T, ap *AggregationProcess, record1,
 		err = ap.addOrUpdateRecordInMap(flowKey2, record2, isIPv4)
 		assert.NoError(t, err)
 	}
-	assert.Equal(t, uint64(1), ap.GetNumberOfFlows())
+	assert.Equal(t, int64(1), ap.GetNumFlows())
 	assert.Equal(t, 1, ap.expirePriorityQueue.Len())
 	aggRecord, _ := ap.flowKeyRecordMap[*flowKey1]
 	item = ap.expirePriorityQueue.Peek()
@@ -966,7 +966,7 @@ func runAggregationAndCheckResult(t *testing.T, ap *AggregationProcess, srcRecor
 		err = ap.addOrUpdateRecordInMap(flowKey, dstRecordLatest, isIPv4)
 		assert.NoError(t, err)
 	}
-	assert.Equal(t, uint64(1), ap.GetNumberOfFlows())
+	assert.Equal(t, int64(1), ap.GetNumFlows())
 	assert.Equal(t, 1, ap.expirePriorityQueue.Len())
 	aggRecord, _ := ap.flowKeyRecordMap[*flowKey]
 	item = ap.expirePriorityQueue.Peek()


### PR DESCRIPTION
This commit modifies some of the methods used for flow visibility
and their return type to keep consistent with Antrea repository.