### PR TITLE
Update GetRecords in AggregationProcess to return map format records

### DIFF
--- a/pkg/entities/record.go
+++ b/pkg/entities/record.go
@@ -40,7 +40,7 @@ type Record interface {
 	GetInfoElementWithValue(name string) (InfoElementWithValue, int, bool)
 	GetRecordLength() int
 	GetMinDataRecordLen() uint16
-	GetString() string
+	GetElementMap() map[string]interface{}
 }
 
 type baseRecord struct {
@@ -112,51 +112,52 @@ func (b *baseRecord) GetInfoElementWithValue(name string) (InfoElementWithValue,
 	return nil, 0, false
 }
 
-func (b *baseRecord) GetString() string {
-	var recordString string
-	for _, ie := range b.GetOrderedElementList() {
-		switch ie.GetDataType() {
+func (b *baseRecord) GetElementMap() map[string]interface{} {
+	elements := make(map[string]interface{})
+	orderedElements := b.GetOrderedElementList()
+	for _, element := range orderedElements {
+		switch element.GetDataType() {
 		case Unsigned8:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned8Value())
+			elements[element.GetName()] = element.GetUnsigned8Value()
 		case Unsigned16:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned16Value())
+			elements[element.GetName()] = element.GetUnsigned16Value()
 		case Unsigned32:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned32Value())
+			elements[element.GetName()] = element.GetUnsigned32Value()
 		case Unsigned64:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned64Value())
+			elements[element.GetName()] = element.GetUnsigned64Value()
 		case Signed8:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetSigned8Value())
+			elements[element.GetName()] = element.GetSigned8Value()
 		case Signed16:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetSigned16Value())
+			elements[element.GetName()] = element.GetSigned16Value()
 		case Signed32:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetSigned32Value())
+			elements[element.GetName()] = element.GetSigned32Value()
 		case Signed64:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetSigned64Value())
+			elements[element.GetName()] = element.GetSigned64Value()
 		case Float32:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetFloat32Value())
+			elements[element.GetName()] = element.GetFloat32Value()
 		case Float64:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetFloat64Value())
+			elements[element.GetName()] = element.GetFloat64Value()
 		case Boolean:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetBooleanValue())
+			elements[element.GetName()] = element.GetBooleanValue()
 		case DateTimeSeconds:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned32Value())
+			elements[element.GetName()] = element.GetUnsigned32Value()
 		case DateTimeMilliseconds:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetUnsigned64Value())
+			elements[element.GetName()] = element.GetUnsigned64Value()
 		case DateTimeMicroseconds, DateTimeNanoseconds:
 			err := fmt.Errorf("API does not support micro and nano seconds types yet")
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), err)
+			elements[element.GetName()] = err
 		case MacAddress:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetMacAddressValue())
+			elements[element.GetName()] = element.GetMacAddressValue()
 		case Ipv4Address, Ipv6Address:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetIPAddressValue())
+			elements[element.GetName()] = element.GetIPAddressValue()
 		case String:
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), ie.GetStringValue())
+			elements[element.GetName()] = element.GetStringValue()
 		default:
 			err := fmt.Errorf("API supports only valid information elements with datatypes given in RFC7011")
-			recordString += fmt.Sprintf("    %s: %v \n", ie.GetName(), err)
+			elements[element.GetName()] = err
 		}
 	}
-	return recordString
+	return elements
 }
 
 func (d *dataRecord) PrepareRecord() error {

--- a/pkg/entities/record_test.go
+++ b/pkg/entities/record_test.go
@@ -15,7 +15,6 @@
 package entities
 
 import (
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -167,7 +166,7 @@ func TestGetInfoElementWithValue(t *testing.T) {
 	assert.Empty(t, infoElementWithValue)
 }
 
-func TestGetString(t *testing.T) {
+func TestGetElementMap(t *testing.T) {
 	ieList := []*InfoElement{
 		// Test element of each type
 		NewInfoElement("protocolIdentifier", 4, 1, 0, 1),  // unsigned8
@@ -246,17 +245,17 @@ func TestGetString(t *testing.T) {
 		}
 		record.AddInfoElement(ie)
 	}
-	recordString := record.GetString()
-	assert.Contains(t, recordString, fmt.Sprintf("    protocolIdentifier: %d \n", valList.proto))
-	assert.Contains(t, recordString, fmt.Sprintf("    sourceTransportPort: %d \n", valList.srcPort))
-	assert.Contains(t, recordString, fmt.Sprintf("    ingressInterface: %d \n", valList.ingressInt))
-	assert.Contains(t, recordString, fmt.Sprintf("    packetDeltaCount: %d \n", valList.pktCount))
-	assert.Contains(t, recordString, fmt.Sprintf("    mibObjectValueInteger: %d \n", valList.minObjVal))
-	assert.Contains(t, recordString, fmt.Sprintf("    samplingProbability: %v \n", valList.samplingProb))
-	assert.Contains(t, recordString, fmt.Sprintf("    dataRecordsReliability: %t \n", valList.dataReliable))
-	assert.Contains(t, recordString, fmt.Sprintf("    flowStartSeconds: %d \n", valList.flowStartSecs))
-	assert.Contains(t, recordString, fmt.Sprintf("    flowStartMilliseconds: %d \n", valList.flowStartMillisecs))
-	assert.Contains(t, recordString, fmt.Sprintf("    sourceMacAddress: %s \n", valList.macAddr))
-	assert.Contains(t, recordString, fmt.Sprintf("    sourceIPv4Address: %s \n", valList.ipAddr))
-	assert.Contains(t, recordString, fmt.Sprintf("    interfaceDescription: %s \n", valList.stringVal))
+	elements := record.GetElementMap()
+	assert.Equal(t, valList.proto, elements["protocolIdentifier"])
+	assert.Equal(t, valList.srcPort, elements["sourceTransportPort"])
+	assert.Equal(t, valList.ingressInt, elements["ingressInterface"])
+	assert.Equal(t, valList.pktCount, elements["packetDeltaCount"])
+	assert.Equal(t, valList.minObjVal, elements["mibObjectValueInteger"])
+	assert.Equal(t, valList.samplingProb, elements["samplingProbability"])
+	assert.Equal(t, valList.dataReliable, elements["dataRecordsReliability"])
+	assert.Equal(t, valList.flowStartSecs, elements["flowStartSeconds"])
+	assert.Equal(t, valList.flowStartMillisecs, elements["flowStartMilliseconds"])
+	assert.Equal(t, valList.macAddr, elements["sourceMacAddress"])
+	assert.Equal(t, valList.ipAddr, elements["sourceIPv4Address"])
+	assert.Equal(t, valList.stringVal, elements["interfaceDescription"])
 }

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -75,6 +75,20 @@ func (mr *MockRecordMockRecorder) GetBuffer() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuffer", reflect.TypeOf((*MockRecord)(nil).GetBuffer))
 }
 
+// GetElementMap mocks base method
+func (m *MockRecord) GetElementMap() map[string]interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetElementMap")
+	ret0, _ := ret[0].(map[string]interface{})
+	return ret0
+}
+
+// GetElementMap indicates an expected call of GetElementMap
+func (mr *MockRecordMockRecorder) GetElementMap() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetElementMap", reflect.TypeOf((*MockRecord)(nil).GetElementMap))
+}
+
 // GetFieldCount mocks base method
 func (m *MockRecord) GetFieldCount() uint16 {
 	m.ctrl.T.Helper()
@@ -145,20 +159,6 @@ func (m *MockRecord) GetRecordLength() int {
 func (mr *MockRecordMockRecorder) GetRecordLength() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecordLength", reflect.TypeOf((*MockRecord)(nil).GetRecordLength))
-}
-
-// GetString mocks base method
-func (m *MockRecord) GetString() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetString")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetString indicates an expected call of GetString
-func (mr *MockRecordMockRecorder) GetString() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetString", reflect.TypeOf((*MockRecord)(nil).GetString))
 }
 
 // GetTemplateID mocks base method

--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -215,19 +215,20 @@ func (a *AggregationProcess) GetExpiryFromExpirePriorityQueue() time.Duration {
 	return a.inactiveExpiryTimeout
 }
 
-// GetRecords returns the string format flow records by FlowKey from flowKeyRecordMap.
-// Returns partial match if FlowKey is not complete.
-// Returns all the flow records if FlowKey is not provided.
-func (a *AggregationProcess) GetRecords(flowKey *FlowKey) []string {
+// GetRecords returns map format flow records given a flow key.
+// The key of the map is the element name and the value is the IE object.
+// Returns partially matched flow records if the flow key is not complete.
+// Returns all the flow records if the flow key is not provided.
+func (a *AggregationProcess) GetRecords(flowKey *FlowKey) []map[string]interface{} {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
-	var records []string
+	var records []map[string]interface{}
 	// Complete filter
 	if flowKey != nil && flowKey.SourceAddress != "" && flowKey.DestinationAddress != "" &&
 		flowKey.Protocol != 0 && flowKey.SourcePort != 0 && flowKey.DestinationPort != 0 {
 		if record, ok := a.flowKeyRecordMap[*flowKey]; ok {
-			records = append(records, record.Record.GetString())
+			records = append(records, record.Record.GetElementMap())
 		}
 		return records
 	}
@@ -242,7 +243,7 @@ func (a *AggregationProcess) GetRecords(flowKey *FlowKey) []string {
 				continue
 			}
 		}
-		records = append(records, record.Record.GetString())
+		records = append(records, record.Record.GetElementMap())
 	}
 	return records
 }


### PR DESCRIPTION
This commit updates the return type of GetRecords in AggregationProcess from string to map, which makes it more easier to be structured.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>