### PR TITLE
Don't stop upon packet decode errors

### DIFF
--- a/pkg/collector/udp.go
+++ b/pkg/collector/udp.go
@@ -138,7 +138,7 @@ func (cp *CollectingProcess) handleUDPClient(address net.Addr) {
 					message, err := cp.decodePacket(packet, address.String())
 					if err != nil {
 						klog.Error(err)
-						return
+						continue
 					}
 					klog.V(4).Infof("Processed message from exporter %v, number of records: %v, observation domain ID: %v",
 						message.GetExportAddress(), message.GetSet().GetNumberOfRecords(), message.GetObsDomainID())


### PR DESCRIPTION
We shouldn't stop the collector if it happens to receive a dataset packet before the corresponding template