### PR TITLE
Refactor TLS client config for exporter

### DIFF
--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -61,6 +61,19 @@ type ExportingProcess struct {
 	jsonBufferLen   int
 }
 
+type ExporterTLSClientConfig struct {
+	// ServerName is passed to the server for SNI and is used in the client to check server
+	// certificates against. If ServerName is empty, the hostname used to contact the
+	// server is used.
+	ServerName string
+	// CAData holds PEM-encoded bytes for trusted root certificates for server.
+	CAData []byte
+	// CertData holds PEM-encoded bytes.
+	CertData []byte
+	// KeyData holds PEM-encoded bytes.
+	KeyData []byte
+}
+
 type ExporterInput struct {
 	// CollectorAddress needs to be provided in hostIP:port format.
 	CollectorAddress string
@@ -69,14 +82,12 @@ type ExporterInput struct {
 	CollectorProtocol   string
 	ObservationDomainID uint32
 	TempRefTimeout      uint32
-	IsEncrypted         bool
-	CACert              []byte
-	ClientCert          []byte
-	ClientKey           []byte
-	IsIPv6              bool
-	SendJSONRecord      bool
-	JSONBufferLen       int
-	CheckConnInterval   time.Duration
+	// TLSClientConfig is set to use an encrypted connection to the collector.
+	TLSClientConfig   *ExporterTLSClientConfig
+	IsIPv6            bool
+	SendJSONRecord    bool
+	JSONBufferLen     int
+	CheckConnInterval time.Duration
 }
 
 // InitExportingProcess takes in collector address(net.Addr format), obsID(observation ID)
@@ -93,9 +104,10 @@ type ExporterInput struct {
 func InitExportingProcess(input ExporterInput) (*ExportingProcess, error) {
 	var conn net.Conn
 	var err error
-	if input.IsEncrypted {
+	if input.TLSClientConfig != nil {
+		tlsConfig := input.TLSClientConfig
 		if input.CollectorProtocol == "tcp" { // use TLS
-			config, configErr := createClientConfig(input.CACert, input.ClientCert, input.ClientKey)
+			config, configErr := createClientConfig(tlsConfig)
 			if configErr != nil {
 				return nil, configErr
 			}
@@ -105,13 +117,20 @@ func InitExportingProcess(input ExporterInput) (*ExportingProcess, error) {
 				return nil, err
 			}
 		} else if input.CollectorProtocol == "udp" { // use DTLS
+			// TODO: support client authentication
+			if len(tlsConfig.CertData) > 0 || len(tlsConfig.KeyData) > 0 {
+				klog.Error("Client-authentication is not supported yet for DTLS, cert and key data will be ignored")
+			}
 			roots := x509.NewCertPool()
-			ok := roots.AppendCertsFromPEM(input.CACert)
+			ok := roots.AppendCertsFromPEM(tlsConfig.CAData)
 			if !ok {
 				return nil, fmt.Errorf("failed to parse root certificate")
 			}
-			config := &dtls.Config{RootCAs: roots,
-				ExtendedMasterSecret: dtls.RequireExtendedMasterSecret}
+			config := &dtls.Config{
+				RootCAs:              roots,
+				ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
+				ServerName:           tlsConfig.ServerName,
+			}
 			udpAddr, err := net.ResolveUDPAddr(input.CollectorProtocol, input.CollectorAddress)
 			if err != nil {
 				return nil, err
@@ -465,19 +484,20 @@ func isChanClosed(ch <-chan struct{}) bool {
 	return false
 }
 
-func createClientConfig(caCert, clientCert, clientKey []byte) (*tls.Config, error) {
+func createClientConfig(config *ExporterTLSClientConfig) (*tls.Config, error) {
 	roots := x509.NewCertPool()
-	ok := roots.AppendCertsFromPEM(caCert)
+	ok := roots.AppendCertsFromPEM(config.CAData)
 	if !ok {
 		return nil, fmt.Errorf("failed to parse root certificate")
 	}
-	if clientCert == nil {
+	if config.CertData == nil {
 		return &tls.Config{
 			RootCAs:    roots,
 			MinVersion: tls.VersionTLS12,
+			ServerName: config.ServerName,
 		}, nil
 	}
-	cert, err := tls.X509KeyPair(clientCert, clientKey)
+	cert, err := tls.X509KeyPair(config.CertData, config.KeyData)
 	if err != nil {
 		return nil, err
 	}
@@ -485,5 +505,6 @@ func createClientConfig(caCert, clientCert, clientKey []byte) (*tls.Config, erro
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      roots,
 		MinVersion:   tls.VersionTLS12,
+		ServerName:   config.ServerName,
 	}, nil
 }

--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -16,12 +16,15 @@ package exporter
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"io"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/pion/dtls/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/registry"
@@ -392,6 +395,156 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	exporter.CloseConnToCollector()
 }
 
+func TestInitExportingProcessWithTLS(t *testing.T) {
+	caCert, caKey, caData, err := test.GenerateCACert()
+	require.NoError(t, err, "Error when generating CA cert")
+	clientCertData, clientKeyData, err := test.GenerateClientCert(caCert, caKey)
+	require.NoError(t, err, "Error when generating client cert")
+
+	testCases := []struct {
+		name              string
+		serverCertOptions []test.CertificateOption
+		withClientAuth    bool
+		tlsClientConfig   *ExporterTLSClientConfig
+		expectedErr       string
+		expectedServerErr string
+	}{
+		{
+			name: "no SANs",
+			tlsClientConfig: &ExporterTLSClientConfig{
+				CAData: caData,
+			},
+			expectedErr:       "x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs",
+			expectedServerErr: "tls: bad certificate",
+		},
+		{
+			name:              "IP SAN",
+			serverCertOptions: []test.CertificateOption{test.AddIPAddress(net.ParseIP("127.0.0.1"))},
+			tlsClientConfig: &ExporterTLSClientConfig{
+				CAData: caData,
+			},
+		},
+		{
+			name:              "name SAN with matching ServerName",
+			serverCertOptions: []test.CertificateOption{test.AddDNSName("foobar")},
+			tlsClientConfig: &ExporterTLSClientConfig{
+				CAData:     caData,
+				ServerName: "foobar",
+			},
+		},
+		{
+			name:              "name SAN with mismatching ServerName",
+			serverCertOptions: []test.CertificateOption{test.AddDNSName("foobar")},
+			tlsClientConfig: &ExporterTLSClientConfig{
+				CAData:     caData,
+				ServerName: "badname",
+			},
+			expectedErr:       "x509: certificate is valid for foobar, not badname",
+			expectedServerErr: "tls: bad certificate",
+		},
+		{
+			name:              "name SAN without ServerName",
+			serverCertOptions: []test.CertificateOption{test.AddDNSName("foobar")},
+			tlsClientConfig: &ExporterTLSClientConfig{
+				CAData: caData,
+			},
+			expectedErr:       "x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs",
+			expectedServerErr: "tls: bad certificate",
+		},
+		{
+			name:              "client auth with no cert",
+			serverCertOptions: []test.CertificateOption{test.AddIPAddress(net.ParseIP("127.0.0.1"))},
+			withClientAuth:    true,
+			tlsClientConfig: &ExporterTLSClientConfig{
+				CAData: caData,
+			},
+			expectedServerErr: "tls: client didn't provide a certificate",
+		},
+		{
+			name:              "client auth with cert",
+			serverCertOptions: []test.CertificateOption{test.AddIPAddress(net.ParseIP("127.0.0.1"))},
+			withClientAuth:    true,
+			tlsClientConfig: &ExporterTLSClientConfig{
+				CAData:   caData,
+				CertData: clientCertData,
+				KeyData:  clientKeyData,
+			},
+		},
+		{
+			name:              "client auth and ServerName",
+			serverCertOptions: []test.CertificateOption{test.AddDNSName("foobar")},
+			withClientAuth:    true,
+			tlsClientConfig: &ExporterTLSClientConfig{
+				CAData:     caData,
+				CertData:   clientCertData,
+				KeyData:    clientKeyData,
+				ServerName: "foobar",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Create local server for testing
+			address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			serverCertData, serverKeyData, err := test.GenerateServerCert(caCert, caKey, tc.serverCertOptions...)
+			require.NoError(t, err, "Error when generating server cert")
+			serverCert, err := tls.X509KeyPair(serverCertData, serverKeyData)
+			require.NoError(t, err)
+			config := &tls.Config{
+				Certificates: []tls.Certificate{serverCert},
+				MinVersion:   tls.VersionTLS12,
+			}
+			if tc.withClientAuth {
+				certPool := x509.NewCertPool()
+				certPool.AppendCertsFromPEM(caData)
+				config.ClientAuth = tls.RequireAndVerifyClientCert
+				config.ClientCAs = certPool
+			}
+			listener, err := tls.Listen("tcp", address.String(), config)
+			require.NoError(t, err, "Error when starting server")
+			serverErrCh := make(chan error)
+
+			go func() {
+				defer listener.Close()
+				conn, err := listener.Accept()
+				if err != nil {
+					return
+				}
+				defer conn.Close()
+				t.Log("Accept the connection from exporter")
+				_, err = io.ReadAll(conn)
+				serverErrCh <- err
+			}()
+
+			input := ExporterInput{
+				CollectorAddress:    listener.Addr().String(),
+				CollectorProtocol:   listener.Addr().Network(),
+				ObservationDomainID: 1,
+				TempRefTimeout:      0,
+				TLSClientConfig:     tc.tlsClientConfig,
+			}
+			exporter, err := InitExportingProcess(input)
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			if err == nil {
+				exporter.CloseConnToCollector()
+			}
+			serverErr := <-serverErrCh
+			if tc.expectedServerErr != "" {
+				assert.ErrorContains(t, serverErr, tc.expectedServerErr)
+			} else {
+				assert.NoError(t, serverErr)
+			}
+		})
+	}
+}
+
 func TestExportingProcessWithTLS(t *testing.T) {
 	// Create local server for testing
 	address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
@@ -438,8 +591,10 @@ func TestExportingProcessWithTLS(t *testing.T) {
 		CollectorProtocol:   listener.Addr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
-		IsEncrypted:         true,
-		CACert:              []byte(test.FakeCACert),
+		TLSClientConfig: &ExporterTLSClientConfig{
+			CAData:     []byte(test.FakeCACert),
+			ServerName: "127.0.0.1",
+		},
 	}
 	exporter, err := InitExportingProcess(input)
 	if err != nil {
@@ -523,8 +678,9 @@ func TestExportingProcessWithDTLS(t *testing.T) {
 		CollectorProtocol:   listener.Addr().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
-		IsEncrypted:         true,
-		CACert:              []byte(test.FakeCert2),
+		TLSClientConfig: &ExporterTLSClientConfig{
+			CAData: []byte(test.FakeCert2),
+		},
 	}
 	exporter, err := InitExportingProcess(input)
 	if err != nil {

--- a/pkg/test/certs.go
+++ b/pkg/test/certs.go
@@ -14,6 +14,20 @@
 
 package test
 
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"time"
+)
+
 const (
 	// TODO: update the certs before 2025-02-01
 	FakeCACert = `-----BEGIN CERTIFICATE-----
@@ -161,3 +175,150 @@ wzvYQtp9CSqd
 -----END CERTIFICATE-----
 `
 )
+
+var (
+	validFrom = time.Now()
+	maxAge    = time.Hour * 24 * 365 // one year self-signed certs
+)
+
+// We also provide these utility functions to generate test certificates dynamically.
+
+type CertificateOption func(*x509.Certificate)
+
+func AddDNSName(name string) CertificateOption {
+	return func(cert *x509.Certificate) {
+		cert.DNSNames = append(cert.DNSNames, name)
+	}
+}
+
+func AddIPAddress(addr net.IP) CertificateOption {
+	return func(cert *x509.Certificate) {
+		cert.IPAddresses = append(cert.IPAddresses, addr)
+	}
+}
+
+func GenerateCACert(options ...CertificateOption) (*x509.Certificate, *rsa.PrivateKey, []byte, error) {
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("test-ca@%d", time.Now().Unix()),
+		},
+		NotBefore:             validFrom,
+		NotAfter:              validFrom.Add(maxAge),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	for _, option := range options {
+		option(cert)
+	}
+	// generate private key for CA
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// generate CA certificate
+	caCert, err := x509.CreateCertificate(rand.Reader, cert, cert, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caPEM := bytes.Buffer{}
+	pem.Encode(&caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caCert,
+	})
+
+	return cert, caKey, caPEM.Bytes(), err
+}
+
+func randSerialNumberOrDie() *big.Int {
+	max := big.NewInt(math.MaxUint32)
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		panic("Error when generating random cert serial number")
+	}
+	return n
+}
+
+func GenerateClientCert(caCert *x509.Certificate, caKey *rsa.PrivateKey, options ...CertificateOption) ([]byte, []byte, error) {
+	cert := &x509.Certificate{
+		SerialNumber: randSerialNumberOrDie(),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("client-certificate@%d", time.Now().Unix()),
+		},
+		NotBefore:   validFrom,
+		NotAfter:    validFrom.Add(maxAge),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+	}
+	for _, option := range options {
+		option(cert)
+	}
+	// generate private key for certificate
+	certKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	// sign the certificate using CA certificate and key
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, &certKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := bytes.Buffer{}
+	pem.Encode(&certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	certKeyPEM := bytes.Buffer{}
+	pem.Encode(&certKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certKey),
+	})
+
+	return certPEM.Bytes(), certKeyPEM.Bytes(), nil
+}
+
+func GenerateServerCert(caCert *x509.Certificate, caKey *rsa.PrivateKey, options ...CertificateOption) ([]byte, []byte, error) {
+	cert := &x509.Certificate{
+		SerialNumber: randSerialNumberOrDie(),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("server-certificate@%d", time.Now().Unix()),
+		},
+		NotBefore:   validFrom,
+		NotAfter:    validFrom.Add(maxAge),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		IPAddresses: []net.IP{},
+		DNSNames:    []string{},
+	}
+	for _, option := range options {
+		option(cert)
+	}
+	// generate private key for certificate
+	certKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	// sign the certificate using CA certificate and key
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, &certKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := bytes.Buffer{}
+	pem.Encode(&certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	certKeyPEM := bytes.Buffer{}
+	pem.Encode(&certKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certKey),
+	})
+
+	return certPEM.Bytes(), certKeyPEM.Bytes(), nil
+}

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -136,18 +136,18 @@ func testExporterToCollector(address net.Addr, isSrcNode, isIPv6 bool, isMultipl
 		CollectorProtocol:   cp.GetAddress().Network(),
 		ObservationDomainID: 1,
 		TempRefTimeout:      0,
-		IsEncrypted:         isEncrypted,
-		CACert:              nil,
 		CheckConnInterval:   time.Millisecond,
 	}
 	if isEncrypted {
+		tlsClientConfig := &exporter.ExporterTLSClientConfig{}
 		if address.Network() == "tcp" { // use TLS
-			epInput.CACert = []byte(FakeCACert)
-			epInput.ClientCert = []byte(FakeClientCert)
-			epInput.ClientKey = []byte(FakeClientKey)
+			tlsClientConfig.CAData = []byte(FakeCACert)
+			tlsClientConfig.CertData = []byte(FakeClientCert)
+			tlsClientConfig.KeyData = []byte(FakeClientKey)
 		} else if address.Network() == "udp" { // use DTLS
-			epInput.CACert = []byte(FakeCert2)
+			tlsClientConfig.CAData = []byte(FakeCert2)
 		}
+		epInput.TLSClientConfig = tlsClientConfig
 	}
 	export, err := exporter.InitExportingProcess(epInput)
 	if err != nil {


### PR DESCRIPTION
* move configuration parameters to their own struct and try to use better names
* add ServerName configuration parameter so that clients are able to provide a custom name to check server certificates against

The inspiration is
https://pkg.go.dev/k8s.io/client-go/rest#TLSClientConfig

This is a breaking change for clients, but should be ok since we haven't made a v1.0 release yet for go-ipfix.

Signed-off-by: Antonin Bas <abas@vmware.com>