### PR TITLE
--v is no longer supported

### DIFF
--- a/build/yamls/ipfix-collector.yaml
+++ b/build/yamls/ipfix-collector.yaml
@@ -48,7 +48,6 @@ spec:
     spec:
       containers:
       - args:
-        - --v=0
         - --ipfix.port=4739
         - --ipfix.transport=tcp
         image: projects.registry.vmware.com/antrea/ipfix-collector:latest


### PR DESCRIPTION
Fixing yaml for unsupported `--v` option:

```
Error: unknown flag: --v
Usage:
  ipfix-collector [flags]

Flags:
  -h, --help                     help for ipfix-collector
      --ipfix.addr string        IPFIX collector address (default "0.0.0.0")
      --ipfix.port uint16        IPFIX collector port (default 4739)
      --ipfix.transport string   IPFIX collector transport layer (default "tcp")
```