### PR TITLE
Add fields for Egress information support

### DIFF
--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -87,7 +87,6 @@ func printIPFIXMessage(msg *entities.Message) {
 				case entities.Unsigned8:
 					fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, ie.GetUnsigned8Value())
 				case entities.Unsigned16:
-
 					fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, ie.GetUnsigned16Value())
 				case entities.Unsigned32:
 					fmt.Fprintf(&buf, "    %s: %v \n", elem.Name, ie.GetUnsigned32Value())

--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -52,3 +52,5 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 150,reverseThroughputFromDestinationNode,unsigned64,,current,,,,,,,,56506,
 151,flowEndSecondsFromSourceNode,unsigned32,,current,,,,,,,,56506,
 152,flowEndSecondsFromDestinationNode,unsigned32,,current,,,,,,,,56506,
+153,egressName,string,,current,,,,,,,,56506,
+154,egressIP,string,,current,,,,,,,,56506,

--- a/pkg/registry/registry_antrea.go
+++ b/pkg/registry/registry_antrea.go
@@ -74,4 +74,6 @@ func loadAntreaRegistry() {
 	registerInfoElement(*entities.NewInfoElement("reverseThroughputFromDestinationNode", 150, 4, 56506, 8), 56506)
 	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromSourceNode", 151, 14, 56506, 4), 56506)
 	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromDestinationNode", 152, 14, 56506, 4), 56506)
+	registerInfoElement(*entities.NewInfoElement("egressName", 153, 13, 56506, 65535), 56506)
+	registerInfoElement(*entities.NewInfoElement("egressIP", 154, 13, 56506, 65535), 56506)
 }


### PR DESCRIPTION
Add two new fields egressName and egressIP for the visibility of Egress information in flow records.

Changes in Antrea: https://github.com/antrea-io/antrea/pull/5088