### PR TITLE
Adding L7 visibility fields

### DIFF
--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -54,3 +54,5 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 152,flowEndSecondsFromDestinationNode,dateTimeSeconds,,current,,,,,,,,56506,
 153,egressName,string,,current,,,,,,,,56506,
 154,egressIP,string,,current,,,,,,,,56506,
+155,isL7,boolean,,current,,,,,,,,56506,
+156,httpVals,string,,current,,,,,,,,56506,

--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -54,5 +54,5 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 152,flowEndSecondsFromDestinationNode,dateTimeSeconds,,current,,,,,,,,56506,
 153,egressName,string,,current,,,,,,,,56506,
 154,egressIP,string,,current,,,,,,,,56506,
-155,isL7,boolean,,current,,,,,,,,56506,
+155,l7ProtocolName,string,,current,,,,,,,,56506,
 156,httpVals,string,,current,,,,,,,,56506,

--- a/pkg/registry/registry_antrea.go
+++ b/pkg/registry/registry_antrea.go
@@ -72,8 +72,10 @@ func loadAntreaRegistry() {
 	registerInfoElement(*entities.NewInfoElement("throughputFromDestinationNode", 148, 4, 56506, 8), 56506)
 	registerInfoElement(*entities.NewInfoElement("reverseThroughputFromSourceNode", 149, 4, 56506, 8), 56506)
 	registerInfoElement(*entities.NewInfoElement("reverseThroughputFromDestinationNode", 150, 4, 56506, 8), 56506)
-	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromSourceNode", 151, 14, 56506, 4), 56506)
-	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromDestinationNode", 152, 14, 56506, 4), 56506)
+	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromSourceNode", 151, 3, 56506, 4), 56506)
+	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromDestinationNode", 152, 3, 56506, 4), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressName", 153, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressIP", 154, 13, 56506, 65535), 56506)
+	registerInfoElement(*entities.NewInfoElement("isL7", 155, 11, 56506, 1), 56506)
+	registerInfoElement(*entities.NewInfoElement("httpVals", 156, 13, 56506, 65535), 56506)
 }

--- a/pkg/registry/registry_antrea.go
+++ b/pkg/registry/registry_antrea.go
@@ -72,10 +72,10 @@ func loadAntreaRegistry() {
 	registerInfoElement(*entities.NewInfoElement("throughputFromDestinationNode", 148, 4, 56506, 8), 56506)
 	registerInfoElement(*entities.NewInfoElement("reverseThroughputFromSourceNode", 149, 4, 56506, 8), 56506)
 	registerInfoElement(*entities.NewInfoElement("reverseThroughputFromDestinationNode", 150, 4, 56506, 8), 56506)
-	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromSourceNode", 151, 3, 56506, 4), 56506)
-	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromDestinationNode", 152, 3, 56506, 4), 56506)
+	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromSourceNode", 151, 14, 56506, 4), 56506)
+	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromDestinationNode", 152, 14, 56506, 4), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressName", 153, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressIP", 154, 13, 56506, 65535), 56506)
-	registerInfoElement(*entities.NewInfoElement("isL7", 155, 11, 56506, 1), 56506)
+	registerInfoElement(*entities.NewInfoElement("l7ProtocolName", 155, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("httpVals", 156, 13, 56506, 65535), 56506)
 }


### PR DESCRIPTION
Adding L7 visibility fields to the Ipfix table.

l7ProtocolName: field is used to store application layer protocol name, field will be empty if application layer flow is not exported.
httpVals: The field is added to contain all the http values and store them as a string of Json similar to labels. This helps us to store multiple http Vals for a single flow which is possible in case of persistent http.

Mistakenly removed #314