### PR TITLE
Improve handling of string IEs

### DIFF
--- a/pkg/entities/ie_test.go
+++ b/pkg/entities/ie_test.go
@@ -93,7 +93,7 @@ func BenchmarkEncodeInfoElementValueToBuffShortString(b *testing.B) {
 }
 
 func BenchmarkEncodeInfoElementValueToBuffLongString(b *testing.B) {
-	// a long string has a max length of 65534
+	// a long string has a max length of 65535
 	str := strings.Repeat("x", 10000)
 	element := NewStringInfoElement(NewInfoElement("interfaceDescription", 83, 13, 0, 65535), str)
 	const numCopies = 1000


### PR DESCRIPTION
* Use the copy built-in to copy string bytes to buffer, instead of copying bytes one-by-one with a for loop. This is more efficient (confirmed with new Benchmark functions) and more correct (in case the string includes UTF-8 characters which use more than 1 byte).
* Increase max string length from 65,534 to 65,535.