### PR TITLE
Fix aggregation bug for throughput common fields

### DIFF
--- a/pkg/intermediate/aggregate.go
+++ b/pkg/intermediate/aggregate.go
@@ -637,8 +637,10 @@ func (a *AggregationProcess) aggregateRecords(incomingRecord, existingRecord ent
 			ie, _, _ := existingRecord.GetInfoElementWithValue(antreaDestinationThroughputElements[i])
 			ie.SetUnsigned64Value(throughputVals[i])
 		}
-		ie, _, _ := existingRecord.GetInfoElementWithValue(element)
-		ie.SetUnsigned64Value(throughputVals[i])
+		if isLatest {
+			ie, _, _ := existingRecord.GetInfoElementWithValue(element)
+			ie.SetUnsigned64Value(throughputVals[i])
+		}
 	}
 	return nil
 }
@@ -756,7 +758,7 @@ func (a *AggregationProcess) addFieldsForThroughputCalculation(record entities.R
 			return err
 		}
 		value := uint32(0)
-		if fillSrcStats && strings.Contains(ieName, "Source") || fillDstStats && strings.Contains(ieName, "Destination") {
+		if (fillSrcStats && strings.Contains(ieName, "Source")) || (fillDstStats && strings.Contains(ieName, "Destination")) {
 			value = timeEnd
 		}
 		if err = record.AddInfoElement(entities.NewUnsigned32InfoElement(ie, value)); err != nil {


### PR DESCRIPTION
Just like for stats, throughput common fields should only be updated for the "latest" record (based on "flowEndSeconds").

This bug explains why the TestCollectorToIntermediate integration test has been flaky for a long time. In some cases, the record from the destination was processed before the record from the source (we have 2 aggregation workers, so records are not guaranteed to be processed in the order in which they are received). While the destination record has a larger "flowEndSeconds", the "throughput" and "reverseThroughput" common elements were overriden by values from the source record.