### PR TITLE
Create copies of net.IP and net.HardwareAddr when decoding IE values

### DIFF
--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -166,6 +166,10 @@ func TestTCPCollectingProcess_ReceiveDataRecordsMemoryUsage(t *testing.T) {
 
 	const numRecords = 1000
 
+	// We collect the IEs containing the source IPv4 address from all the records received by
+	// the collector. We need to make sure that we access the values from this slice *after*
+	// running the garbage collector and collecting memory stats, otherwise everything may be
+	// garbage collected too early and the results of the test will be inaccurate.
 	ies := make([]entities.InfoElementWithValue, 0, numRecords)
 
 	t.Logf("Data packet length: %d", len(validDataPacket))
@@ -185,7 +189,7 @@ func TestTCPCollectingProcess_ReceiveDataRecordsMemoryUsage(t *testing.T) {
 	conn.Close()
 	cp.Stop()
 
-	// force the GC to run before collecting memory stats
+	// Force the GC to run before collecting memory stats
 	runtime.GC()
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)

--- a/pkg/entities/ie.go
+++ b/pkg/entities/ie.go
@@ -318,9 +318,25 @@ func DecodeAndCreateInfoElementWithValue(element *InfoElement, value []byte) (In
 	case DateTimeMicroseconds, DateTimeNanoseconds:
 		return nil, fmt.Errorf("API does not support micro and nano seconds types yet")
 	case MacAddress:
-		return NewMacAddressInfoElement(element, value), nil
+		if value == nil {
+			return NewMacAddressInfoElement(element, nil), nil
+		} else {
+			// make sure that we make a copy of the slice, instead of using it as is
+			// otherwise the underlying array for value may not be GC'd until the IE is GC'd
+			// the underlying array may be much larger than the value slice itself
+			addr := append([]byte{}, value...)
+			return NewMacAddressInfoElement(element, addr), nil
+		}
 	case Ipv4Address, Ipv6Address:
-		return NewIPAddressInfoElement(element, value), nil
+		if value == nil {
+			return NewIPAddressInfoElement(element, nil), nil
+		} else {
+			// make sure that we make a copy of the slice, instead of using it as is
+			// otherwise the underlying array for value may not be GC'd until the IE is GC'd
+			// the underlying array may be much larger than the value slice itself
+			addr := append([]byte{}, value...)
+			return NewIPAddressInfoElement(element, addr), nil
+		}
 	case String:
 		var val string
 		if value == nil {


### PR DESCRIPTION
When using the provided slice (provided by the collector) directly, the garbage collector will not be able to release the underlying array while references to the net objects exist. The underlying array is allocated when reading the message from the TCP connection and can be 100s of bytes in size. The collector will typically run aggregation and keep references to the data record and its IEs for some time. During that time, we cannot release the packet buffer, while new packets keep coming in. To avoid the issue, we create a new slice, with a new underlying array, and the packet buffer can be releases as soon as all IEs are instantiated.