### PR TITLE
Improve memory performance of collector

### DIFF
--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -280,7 +280,7 @@ func (cp *CollectingProcess) decodeTemplateSet(templateBuffer *bytes.Buffer, obs
 			return nil, err
 		}
 	}
-	err := templateSet.AddRecord(elementsWithValue, templateID)
+	err := templateSet.AddRecordV2(elementsWithValue, templateID)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func (cp *CollectingProcess) decodeDataSet(dataBuffer *bytes.Buffer, obsDomainID
 	}
 
 	for dataBuffer.Len() > 0 {
-		elements := make([]entities.InfoElementWithValue, len(template))
+		elements := make([]entities.InfoElementWithValue, len(template), len(template)+cp.numExtraElements)
 		for i, element := range template {
 			var length int
 			if element.Len == entities.VariableLength { // string
@@ -312,7 +312,7 @@ func (cp *CollectingProcess) decodeDataSet(dataBuffer *bytes.Buffer, obsDomainID
 				return nil, err
 			}
 		}
-		err = dataSet.AddRecordWithExtraElements(elements, cp.numExtraElements, templateID)
+		err = dataSet.AddRecordV2(elements, templateID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/entities/testing/mock_set.go
+++ b/pkg/entities/testing/mock_set.go
@@ -66,6 +66,20 @@ func (mr *MockSetMockRecorder) AddRecord(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRecord", reflect.TypeOf((*MockSet)(nil).AddRecord), arg0, arg1)
 }
 
+// AddRecordV2 mocks base method.
+func (m *MockSet) AddRecordV2(arg0 []entities.InfoElementWithValue, arg1 uint16) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddRecordV2", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddRecordV2 indicates an expected call of AddRecordV2.
+func (mr *MockSetMockRecorder) AddRecordV2(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRecordV2", reflect.TypeOf((*MockSet)(nil).AddRecordV2), arg0, arg1)
+}
+
 // AddRecordWithExtraElements mocks base method.
 func (m *MockSet) AddRecordWithExtraElements(arg0 []entities.InfoElementWithValue, arg1 int, arg2 uint16) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Avoid unnecessary slice creation when adding a record to a set. We implement this change for both data record and template records, but in practice most of the gains will come from data records.

Memory allocations (in bytes) are reduced by around 15% for BenchmarkCollector.