### PR TITLE
Rename l7ProtocolName to appProtocol

### DIFF
--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -54,5 +54,5 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 152,flowEndSecondsFromDestinationNode,dateTimeSeconds,,current,,,,,,,,56506,
 153,egressName,string,,current,,,,,,,,56506,
 154,egressIP,string,,current,,,,,,,,56506,
-155,l7ProtocolName,string,,current,,,,,,,,56506,
+155,appProtocolName,string,,current,,,,,,,,56506,
 156,httpVals,string,,current,,,,,,,,56506,

--- a/pkg/registry/registry_antrea.go
+++ b/pkg/registry/registry_antrea.go
@@ -76,6 +76,6 @@ func loadAntreaRegistry() {
 	registerInfoElement(*entities.NewInfoElement("flowEndSecondsFromDestinationNode", 152, 14, 56506, 4), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressName", 153, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressIP", 154, 13, 56506, 65535), 56506)
-	registerInfoElement(*entities.NewInfoElement("l7ProtocolName", 155, 13, 56506, 65535), 56506)
+	registerInfoElement(*entities.NewInfoElement("appProtocolName", 155, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("httpVals", 156, 13, 56506, 65535), 56506)
 }


### PR DESCRIPTION
Keeping the more standardized name for Layer 7 Protocol field