### PR TITLE
Add "egressNodeName" field for Egress information support

### DIFF
--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -56,3 +56,4 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 154,egressIP,string,,current,,,,,,,,56506,
 155,appProtocolName,string,,current,,,,,,,,56506,
 156,httpVals,string,,current,,,,,,,,56506,
+157,egressNodeName,string,,current,,,,,,,,56506,

--- a/pkg/registry/registry_antrea.go
+++ b/pkg/registry/registry_antrea.go
@@ -78,4 +78,5 @@ func loadAntreaRegistry() {
 	registerInfoElement(*entities.NewInfoElement("egressIP", 154, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("appProtocolName", 155, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("httpVals", 156, 13, 56506, 65535), 56506)
+	registerInfoElement(*entities.NewInfoElement("egressNodeName", 157, 13, 56506, 65535), 56506)
 }


### PR DESCRIPTION
Add a new field `egressNodeName` for the visibility of Egress information in flow records.