### PR TITLE
Stop referencing the VMware Harbor registry for ipfix-collector

### DIFF
--- a/build/yamls/collector/templates/ipfix-collector.yaml
+++ b/build/yamls/collector/templates/ipfix-collector.yaml
@@ -49,7 +49,7 @@ spec:
         {{- end }}
         - --ipfix.port={{ .Values.port }}
         - --ipfix.transport={{ .Values.protocol }}
-        image: projects.registry.vmware.com/antrea/ipfix-collector:{{ .Values.image_tag }}
+        image: antrea/ipfix-collector:{{ .Values.image_tag }}
         imagePullPolicy: IfNotPresent
         name: ipfix-collector
         ports:

--- a/build/yamls/ipfix-collector.yaml
+++ b/build/yamls/ipfix-collector.yaml
@@ -50,7 +50,7 @@ spec:
       - args:
         - --ipfix.port=4739
         - --ipfix.transport=tcp
-        image: projects.registry.vmware.com/antrea/ipfix-collector:latest
+        image: antrea/ipfix-collector:latest
         imagePullPolicy: IfNotPresent
         name: ipfix-collector
         ports:


### PR DESCRIPTION
The ipfix-collector YAML manifest should no longer reference the VMware Harbor registry. The image should be pulled from DockerHub.

See https://github.com/antrea-io/antrea/issues/6003