### PR TITLE
Fix how decoding errors are handled for UDP clients in collector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/pion/dtls/v2 v2.2.4
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.9.0
 	go.uber.org/mock v0.3.0
 	google.golang.org/protobuf v1.33.0
 	k8s.io/apimachinery v0.24.9

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -83,7 +83,8 @@ type CollectorInput struct {
 }
 
 type clientHandler struct {
-	packetChan chan *bytes.Buffer
+	packetChan      chan *bytes.Buffer
+	closeClientChan chan struct{}
 }
 
 func InitCollectingProcess(input CollectorInput) (*CollectingProcess, error) {
@@ -151,12 +152,6 @@ func (cp *CollectingProcess) incrementNumRecordsReceived() {
 	cp.mutex.Lock()
 	defer cp.mutex.Unlock()
 	cp.numOfRecordsReceived = cp.numOfRecordsReceived + 1
-}
-
-func (cp *CollectingProcess) createClient() *clientHandler {
-	return &clientHandler{
-		packetChan: make(chan *bytes.Buffer),
-	}
 }
 
 func (cp *CollectingProcess) decodePacket(packetBuffer *bytes.Buffer, exportAddress string) (*entities.Message, error) {

--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -132,8 +132,6 @@ func (cp *CollectingProcess) GetMsgChan() <-chan *entities.Message {
 }
 
 func (cp *CollectingProcess) CloseMsgChan() {
-	cp.mutex.Lock()
-	defer cp.mutex.Unlock()
 	close(cp.messageChan)
 }
 
@@ -159,18 +157,6 @@ func (cp *CollectingProcess) createClient() *clientHandler {
 	return &clientHandler{
 		packetChan: make(chan *bytes.Buffer),
 	}
-}
-
-func (cp *CollectingProcess) addClient(address string, client *clientHandler) {
-	cp.mutex.Lock()
-	defer cp.mutex.Unlock()
-	cp.clients[address] = client
-}
-
-func (cp *CollectingProcess) deleteClient(name string) {
-	cp.mutex.Lock()
-	defer cp.mutex.Unlock()
-	delete(cp.clients, name)
 }
 
 func (cp *CollectingProcess) decodePacket(packetBuffer *bytes.Buffer, exportAddress string) (*entities.Message, error) {

--- a/pkg/collector/tcp.go
+++ b/pkg/collector/tcp.go
@@ -66,7 +66,9 @@ func (cp *CollectingProcess) startTCPServer() {
 
 func (cp *CollectingProcess) handleTCPClient(conn net.Conn) {
 	address := conn.RemoteAddr().String()
-	client := cp.createClient()
+	// The channels stored in clientHandler are not needed for the TCP client, so we do not
+	// initialize them.
+	client := &clientHandler{}
 	func() {
 		cp.mutex.Lock()
 		defer cp.mutex.Unlock()

--- a/pkg/collector/tcp.go
+++ b/pkg/collector/tcp.go
@@ -54,7 +54,10 @@ func (cp *CollectingProcess) startTCPServer() {
 				}
 			}
 			cp.wg.Add(1)
-			go cp.handleTCPClient(conn)
+			go func() {
+				defer cp.wg.Done()
+				cp.handleTCPClient(conn)
+			}()
 		}
 	}(cp.stopChan)
 	<-cp.stopChan
@@ -64,11 +67,21 @@ func (cp *CollectingProcess) startTCPServer() {
 func (cp *CollectingProcess) handleTCPClient(conn net.Conn) {
 	address := conn.RemoteAddr().String()
 	client := cp.createClient()
-	cp.addClient(address, client)
-	defer cp.wg.Done()
+	func() {
+		cp.mutex.Lock()
+		defer cp.mutex.Unlock()
+		cp.clients[address] = client
+	}()
+	defer func() {
+		cp.mutex.Lock()
+		defer cp.mutex.Unlock()
+		delete(cp.clients, address)
+	}()
 	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	cp.wg.Add(1)
 	go func() {
-		reader := bufio.NewReader(conn)
+		defer cp.wg.Done()
 		for {
 			length, err := getMessageLength(reader)
 			if errors.Is(err, io.EOF) {
@@ -77,18 +90,18 @@ func (cp *CollectingProcess) handleTCPClient(conn net.Conn) {
 			}
 			if err != nil {
 				klog.ErrorS(err, "Error when retrieving message length")
-				cp.deleteClient(address)
 				return
 			}
 			buff := make([]byte, length)
 			_, err = io.ReadFull(reader, buff)
 			if err != nil {
 				klog.ErrorS(err, "Error when reading the message")
-				cp.deleteClient(address)
 				return
 			}
 			message, err := cp.decodePacket(bytes.NewBuffer(buff), address)
 			if err != nil {
+				// TODO: should we close the connection instead and force the client to
+				// re-open it?
 				klog.ErrorS(err, "Error when decoding packet")
 				continue
 			}

--- a/pkg/collector/udp.go
+++ b/pkg/collector/udp.go
@@ -63,7 +63,9 @@ func (cp *CollectingProcess) startUDPServer() {
 			return
 		}
 		defer conn.Close()
+		cp.wg.Add(1)
 		go func() {
+			defer cp.wg.Done()
 			buff := make([]byte, cp.maxBufferSize)
 			for {
 				size, err := conn.Read(buff)
@@ -94,7 +96,9 @@ func (cp *CollectingProcess) startUDPServer() {
 		cp.updateAddress(conn.LocalAddr())
 		klog.Infof("Start UDP collecting process on %s", cp.netAddress)
 		defer conn.Close()
+		cp.wg.Add(1)
 		go func() {
+			defer cp.wg.Done()
 			for {
 				buff := make([]byte, cp.maxBufferSize)
 				size, address, err := conn.ReadFromUDP(buff)


### PR DESCRIPTION
Previously, in case of a decoding error (e.g., an unknown template ID in a data set), the goroutine responsible for decoding messages would be stopped, but the client would not be deleted. This would lead to a deadlock as subsequent messages could not be written to the packetChan channel for the client, effectively breaking the UDP collecting process completely. To avoid this issue, we log an error when decoding fails, but keep the client alive. Note that for IPFIX over UDP, there is no way to notify a single UDP client of an error (with TCP, we can close the connection if we want). This is also why the template refresh mechanism exists.

We also fix possible race conditions in the UDP collecting process: all access to the clients map should be protected by locking the mutex.