### PR TITLE
Use correct default value for templateRefreshTimeout

### DIFF
--- a/pkg/collector/udp.go
+++ b/pkg/collector/udp.go
@@ -150,7 +150,7 @@ func (cp *CollectingProcess) createUDPClient(addr string) *clientHandler {
 	cp.wg.Add(1)
 	go func() {
 		defer cp.wg.Done()
-		ticker := time.NewTicker(time.Duration(entities.TemplateRefreshTimeOut) * time.Second)
+		ticker := time.NewTicker(time.Duration(entities.TemplateTTL) * time.Second)
 		defer ticker.Stop()
 		defer close(client.closeClientChan)
 		defer func() {
@@ -178,7 +178,7 @@ func (cp *CollectingProcess) createUDPClient(addr string) *clientHandler {
 				}
 				klog.V(4).Infof("Processed message from exporter %v, number of records: %v, observation domain ID: %v",
 					message.GetExportAddress(), message.GetSet().GetNumberOfRecords(), message.GetObsDomainID())
-				ticker.Reset(time.Duration(entities.TemplateRefreshTimeOut) * time.Second)
+				ticker.Reset(time.Duration(entities.TemplateTTL) * time.Second)
 			}
 		}
 	}()

--- a/pkg/entities/set.go
+++ b/pkg/entities/set.go
@@ -23,8 +23,11 @@ import (
 
 const (
 	// TemplateRefreshTimeOut is the template refresh time out for exporting process
-	TemplateRefreshTimeOut uint32 = 1800
+	// The default is based on https://datatracker.ietf.org/doc/html/rfc5153#section-6.2
+	// and https://datatracker.ietf.org/doc/html/rfc6728#section-4.4.2
+	TemplateRefreshTimeOut uint32 = 600
 	// TemplateTTL is the template time to live for collecting process
+	// See https://datatracker.ietf.org/doc/html/rfc6728#section-4.5.2
 	TemplateTTL = TemplateRefreshTimeOut * 3
 	// TemplateSetID is the setID for template record
 	TemplateSetID uint16 = 2


### PR DESCRIPTION
The correct recommended default is 600s, not 1800s. 1800s is the recommended default for templateLifeTime (3 times
templateRefreshTimeout).

We also update the UDP collector process to timeout the client after templateLifeTime instead of templateRefreshTimeout. This makes more sense as templateLifeTime is a collector process configuration parameter, while templateRefreshTimeout is for the exporter process.