### PR TITLE
Fix connection close in exporter process

### DIFF
--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -744,27 +744,3 @@ func TestExportingProcess_GetMsgSizeLimit(t *testing.T) {
 	t.Logf("Created exporter connecting to local server with address: %s", conn.LocalAddr().String())
 	assert.Equal(t, entities.MaxSocketMsgSize, exporter.GetMsgSizeLimit())
 }
-
-func TestExportingProcess_CheckConnToCollector(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Got error when creating a local server: %v", err)
-	}
-	input := ExporterInput{
-		CollectorAddress:  listener.Addr().String(),
-		CollectorProtocol: listener.Addr().Network(),
-	}
-	exporter, err := InitExportingProcess(input)
-	if err != nil {
-		t.Fatalf("Got error when connecting to local server %s: %v", listener.Addr().String(), err)
-	}
-
-	defer listener.Close()
-	conn, _ := listener.Accept()
-	oneByte := make([]byte, 1)
-	isOpen := exporter.checkConnToCollector(oneByte)
-	assert.True(t, isOpen)
-	conn.Close()
-	isOpen = exporter.checkConnToCollector(oneByte)
-	assert.False(t, isOpen)
-}


### PR DESCRIPTION
There were a couple of issues:

* ConnToCollector is exposed to the consumers of the library, and in Antrea we call ConnToCollector whenever sending a record fails. So the library itself should not call ConnToCollector as this is inherently racy. For example, it is possible for templateRefCh to be closed twice, despite the isChanClosed test (check-then-act race). We could add a mutex and a boolean, but I feel like it is better to just let consumer call ConnToCollector.
* When the exporter process is sending over UDP, there was a typo where a `break` was used instead of `return`. The `break` statement breaks from the select case, and not from the surrounding for loop, so the goroutine would never terminate.