### PR TITLE
Restore check for closed TCP connection in exporter process

### DIFF
--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -744,3 +744,27 @@ func TestExportingProcess_GetMsgSizeLimit(t *testing.T) {
 	t.Logf("Created exporter connecting to local server with address: %s", conn.LocalAddr().String())
 	assert.Equal(t, entities.MaxSocketMsgSize, exporter.GetMsgSizeLimit())
 }
+
+func TestExportingProcess_CheckConnToCollector(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Got error when creating a local server: %v", err)
+	}
+	input := ExporterInput{
+		CollectorAddress:  listener.Addr().String(),
+		CollectorProtocol: listener.Addr().Network(),
+	}
+	exporter, err := InitExportingProcess(input)
+	if err != nil {
+		t.Fatalf("Got error when connecting to local server %s: %v", listener.Addr().String(), err)
+	}
+
+	defer listener.Close()
+	conn, _ := listener.Accept()
+	oneByte := make([]byte, 1)
+	isOpen := exporter.checkConnToCollector(oneByte)
+	assert.True(t, isOpen)
+	conn.Close()
+	isOpen = exporter.checkConnToCollector(oneByte)
+	assert.False(t, isOpen)
+}


### PR DESCRIPTION
This is a partial reversal of d072ed8.
It turns out that the check can actually be useful as it can detect that the collector ("server" side) has closed its side of the connection, and this can be used as a signal to close our side of the connection as well. This can happen when a process using our collector implementation is closed, but no TCP RST is received when sendign a data set (in particular, this can happen when running in K8s and using a virtual IP to connect to the collector). This check can detect the issue much faster than relying on a keep-alive timeout. Furthermore, a client of this library could end up blocking if the connection has not timed out yet and the send buffer is full.