### PR TITLE
Retract version v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,3 +54,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
+
+retract v0.10.0


### PR DESCRIPTION
The "target" of the v0.10.0 tag was "mutated" (the tag was created, then deleted, then created again with a different target commit). This should never be done for a Go module and can create issues for consumers of the module, as the original version will be cached in module proxies, and there will be a discrepancy between module proxies and the version control repository (this can lead to checksum mismatch issues).

The best practice in that case seems to be to retract the invalid version, and release a new one (we will release v0.10.1 in our case).