### PR TITLE
Fix Docker builds for ipfix-collector and kafka-consumer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   build-ipfix-collector:
-    if: ${{ github.event_name == 'push' }}
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +26,6 @@ jobs:
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
           docker push antrea/ipfix-collector:latest
   build-kafka-consumer:
-    if: ${{ github.event_name == 'push' }}
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3

--- a/build/images/Dockerfile.build.collector
+++ b/build/images/Dockerfile.build.collector
@@ -1,4 +1,4 @@
-FROM golang:1.21 as go-ipfix-build
+FROM golang:1.23 as go-ipfix-build
 
 WORKDIR /go-ipfix
 

--- a/build/images/Dockerfile.build.consumer
+++ b/build/images/Dockerfile.build.consumer
@@ -1,4 +1,4 @@
-FROM golang:1.21 as go-ipfix-build
+FROM golang:1.23 as go-ipfix-build
 
 WORKDIR /go-ipfix
 


### PR DESCRIPTION
The go version needs to be updated in the Dockerfiles.

We also make sure that the Github workflow which validates the Docker builds is run for pull requests.