### PR TITLE
Stop using projects.registry.vmware.com registry for Kafka images

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ kubectl apply -f ./build/yamls/kafka-flow-collector.yaml
 ``` 
 Broker address will be `kafka-service.kafka.svc:9092`.
 Notice that `KAFKA_ADVERTISED_LISTENERS` for kafka-broker and broker address should be consistent and accessible
-from other namespaces. Also, versioned images of kafka-broker `projects.registry.vmware.com/antrea/confluentinc-kafka:v6.2.0` 
-and zookeeper `projects.registry.vmware.com/antrea/confluentinc-zookeeper:v6.2.0` are used in the set-up. Proper
-upload of Docker images is required to support more versions.
+from other namespaces. Also, versioned images of kafka-broker `confluentinc/cp-kafka:6.2.0`
+and zookeeper `confluentinc/cp-zookeeper:6.2.0` are used in the set-up. Other
+versions have not been validated.
 
 Currently, `antrea/kafka-consumer` only supports decoding and logging messages with AntreaFlowMsg proto schema.
 

--- a/build/yamls/kafka-flow-collector.yaml
+++ b/build/yamls/kafka-flow-collector.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
         - name: zookeeper
-          image: projects.registry.vmware.com/antrea/confluentinc-zookeeper:6.2.0
+          image: confluentinc/cp-zookeeper:6.2.0
           ports:
             - containerPort: 2181
           env:
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
         - name: kafka
-          image: projects.registry.vmware.com/antrea/confluentinc-kafka:6.2.0
+          image: confluentinc/cp-kafka:6.2.0
           ports:
             - containerPort: 9092
           env:
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
         - name: kafka
-          image: projects.registry.vmware.com/antrea/kafka-consumer
+          image: antrea/kafka-consumer
           imagePullPolicy: IfNotPresent
           args:
             - --brokers=kafka-service.kafka.svc:9092


### PR DESCRIPTION
- For confluent images (Kafka and Zookeeper), we now use the standard images from the confluentinc docker.io organization.
- For the kafka-consumer image, we use antrea/kafka-consumer.