### PR TITLE
Bump codecov/codecov-action to v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,9 +28,11 @@ jobs:
       run: make test-unit
 
     - name: Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: .coverage/coverage_unit.txt
+        disable_search: true
         flags: unit-tests
         name: codecov-unit-test
 
@@ -51,9 +53,11 @@ jobs:
       run: make test-integration
 
     - name: Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: .coverage/coverage_integration.txt
+        disable_search: true
         flags: integration-tests
         name: codecov-integration-test
 

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,4 +11,4 @@ comment:
 
 ignore:
   - "**/testing/mock_*.go"
-  - "pkg/producer/protobuf/*.pb.go"
+  - "**/*.pb.go"


### PR DESCRIPTION
We need to use a token to upload coverage data.
We can also disable coverage data search, as we already provide the list of files (a single file in our case) to include in the report.