### PR TITLE
Add clusterId IE to Antrea registry

### DIFF
--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -57,3 +57,4 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 155,appProtocolName,string,,current,,,,,,,,56506,
 156,httpVals,string,,current,,,,,,,,56506,
 157,egressNodeName,string,,current,,,,,,,,56506,
+158,clusterId,string,,current,,,,,,,,56506,

--- a/pkg/registry/registry_antrea.go
+++ b/pkg/registry/registry_antrea.go
@@ -79,4 +79,5 @@ func loadAntreaRegistry() {
 	registerInfoElement(*entities.NewInfoElement("appProtocolName", 155, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("httpVals", 156, 13, 56506, 65535), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressNodeName", 157, 13, 56506, 65535), 56506)
+	registerInfoElement(*entities.NewInfoElement("clusterId", 158, 13, 56506, 65535), 56506)
 }


### PR DESCRIPTION
As a way to identify the K8s cluster from which the IPFIX record was exported.

The IE is of type string to allow for enough flexibility. This could be a qualified name or a UUID (for example). It should uniquely identify the cluster (to an external IPFIX collector).