### PR TITLE
Ability to support unknown IEs when decoding template sets

### DIFF
--- a/pkg/entities/ie_value.go
+++ b/pkg/entities/ie_value.go
@@ -11,6 +11,7 @@ type InfoElementWithValue interface {
 	// TODO: Handle error to make it more robust if it is called prior to AddInfoElement.
 	GetInfoElement() *InfoElement
 	AddInfoElement(infoElement *InfoElement)
+	GetOctetArrayValue() []byte
 	GetUnsigned8Value() uint8
 	GetUnsigned16Value() uint16
 	GetUnsigned32Value() uint32
@@ -25,6 +26,7 @@ type InfoElementWithValue interface {
 	GetMacAddressValue() net.HardwareAddr
 	GetStringValue() string
 	GetIPAddressValue() net.IP
+	SetOctetArrayValue(val []byte)
 	SetUnsigned8Value(val uint8)
 	SetUnsigned16Value(val uint16)
 	SetUnsigned32Value(val uint32)
@@ -62,6 +64,10 @@ func (b *baseInfoElement) GetInfoElement() *InfoElement {
 
 func (b *baseInfoElement) AddInfoElement(infoElement *InfoElement) {
 	b.element = infoElement
+}
+
+func (b *baseInfoElement) GetOctetArrayValue() []byte {
+	panic("accessing value of wrong data type")
 }
 
 func (b *baseInfoElement) GetUnsigned8Value() uint8 {
@@ -118,6 +124,10 @@ func (b *baseInfoElement) GetStringValue() string {
 
 func (b *baseInfoElement) GetIPAddressValue() net.IP {
 	panic("accessing value of wrong data type")
+}
+
+func (b *baseInfoElement) SetOctetArrayValue(val []byte) {
+	panic("setting value with wrong data type")
 }
 
 func (b *baseInfoElement) SetUnsigned8Value(val uint8) {
@@ -178,6 +188,46 @@ func (b *baseInfoElement) SetIPAddressValue(val net.IP) {
 
 func (b *baseInfoElement) GetLength() int {
 	return int(b.element.Len)
+}
+
+type OctetArrayInfoElement struct {
+	value []byte
+	baseInfoElement
+}
+
+func NewOctetArrayInfoElement(element *InfoElement, val []byte) *OctetArrayInfoElement {
+	infoElem := &OctetArrayInfoElement{
+		value: val,
+	}
+	infoElem.element = element
+	return infoElem
+}
+
+func (a *OctetArrayInfoElement) GetOctetArrayValue() []byte {
+	return a.value
+}
+
+func (a *OctetArrayInfoElement) GetLength() int {
+	if a.element.Len < VariableLength {
+		return int(a.element.Len)
+	}
+	if len(a.value) < 255 {
+		return len(a.value) + 1
+	} else {
+		return len(a.value) + 3
+	}
+}
+
+func (a *OctetArrayInfoElement) SetOctetArrayValue(val []byte) {
+	a.value = val
+}
+
+func (a *OctetArrayInfoElement) IsValueEmpty() bool {
+	return a.value == nil
+}
+
+func (a *OctetArrayInfoElement) ResetValue() {
+	a.value = nil
 }
 
 type Unsigned8InfoElement struct {

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -152,3 +152,27 @@ func TestSet_UpdateLenInHeader(t *testing.T) {
 	// Check the bytes in the header for set length
 	assert.Equal(t, uint16(setForEncoding.GetSetLength()), binary.BigEndian.Uint16(setForEncoding.GetHeaderBuffer()[2:4]))
 }
+
+func TestMakeTemplateSet(t *testing.T) {
+	ie1 := NewInfoElement("sourceIPv4Address", 8, 18, 0, 4)
+	ie2 := NewInfoElement("destinationIPv4Address", 12, 18, 0, 4)
+	s, err := MakeTemplateSet(testTemplateID, []*InfoElement{ie1, ie2})
+	require.NoError(t, err)
+	assert.Equal(t, Template, s.setType)
+	require.Len(t, s.records, 1)
+	assert.Equal(t, map[string]interface{}{
+		"sourceIPv4Address":      net.IP(nil),
+		"destinationIPv4Address": net.IP(nil),
+	}, s.records[0].GetElementMap())
+}
+
+func TestMakeDataSet(t *testing.T) {
+	ie1 := NewIPAddressInfoElement(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("1.1.1.1"))
+	ie2 := NewIPAddressInfoElement(NewInfoElement("destinationIPv4Address", 12, 18, 0, 4), net.ParseIP("1.1.2.1"))
+	elements := []InfoElementWithValue{ie1, ie2}
+	s, err := MakeDataSet(testTemplateID, elements)
+	require.NoError(t, err)
+	assert.Equal(t, Data, s.setType)
+	require.Len(t, s.records, 1)
+	assert.Equal(t, elements, s.records[0].GetOrderedElementList())
+}

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -428,18 +428,7 @@ func (ep *ExportingProcess) sendRefreshedTemplates() error {
 
 	ep.templateMutex.Lock()
 	for templateID, tempValue := range ep.templatesMap {
-		tempSet := entities.NewSet(false)
-		if err := tempSet.PrepareSet(entities.Template, templateID); err != nil {
-			return err
-		}
-		elements := make([]entities.InfoElementWithValue, len(tempValue.elements))
-		var err error
-		for i, element := range tempValue.elements {
-			if elements[i], err = entities.DecodeAndCreateInfoElementWithValue(element, nil); err != nil {
-				return err
-			}
-		}
-		err = tempSet.AddRecord(elements, templateID)
+		tempSet, err := entities.MakeTemplateSet(templateID, tempValue.elements)
 		if err != nil {
 			return err
 		}

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -159,18 +159,15 @@ func getTestRecord(isSrcNode, isIPv6 bool, options ...testRecordOptions) *testRe
 }
 
 func createTemplateSet(templateID uint16, isIPv6 bool) entities.Set {
-	templateSet := entities.NewSet(false)
-	templateSet.PrepareSet(entities.Template, templateID)
-	elements := make([]entities.InfoElementWithValue, 0, numFields)
+	ies := make([]*entities.InfoElement, 0, numFields)
 	ianaFields := ianaIPv4Fields
 	if isIPv6 {
 		ianaFields = ianaIPv6Fields
 	}
 	ianaFields = append(ianaFields, commonFields...)
 	for _, name := range ianaFields {
-		element, _ := registry.GetInfoElement(name, registry.IANAEnterpriseID)
-		ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
-		elements = append(elements, ie)
+		ie, _ := registry.GetInfoElement(name, registry.IANAEnterpriseID)
+		ies = append(ies, ie)
 	}
 	antreaFields := antreaCommonFields
 	if !isIPv6 {
@@ -179,16 +176,14 @@ func createTemplateSet(templateID uint16, isIPv6 bool) entities.Set {
 		antreaFields = append(antreaFields, antreaIPv6...)
 	}
 	for _, name := range antreaFields {
-		element, _ := registry.GetInfoElement(name, registry.AntreaEnterpriseID)
-		ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
-		elements = append(elements, ie)
+		ie, _ := registry.GetInfoElement(name, registry.AntreaEnterpriseID)
+		ies = append(ies, ie)
 	}
 	for _, name := range reverseFields {
-		element, _ := registry.GetInfoElement(name, registry.IANAReversedEnterpriseID)
-		ie, _ := entities.DecodeAndCreateInfoElementWithValue(element, nil)
-		elements = append(elements, ie)
+		ie, _ := registry.GetInfoElement(name, registry.IANAReversedEnterpriseID)
+		ies = append(ies, ie)
 	}
-	templateSet.AddRecord(elements, templateID)
+	templateSet, _ := entities.MakeTemplateSet(templateID, ies)
 	return templateSet
 }
 


### PR DESCRIPTION
Introduce a "decoding mode" configuration for the collector process, which can take one of 3 values: Strict, LenientKeepUnknown, LenientDropUnknown. When the mode is Strict, unknown IEs are rejected. This is the default mode and matches the behavior prior to this patch. When the mode is LenientKeepUnknown, unknown IEs are accepted and will be preserved in data records. When the mode is LenientDropUnknown, unknown IEs are accepted but will not be included in data records (creating a mismatch between the data record and the template).

When decoding is not strict and the IE is not found in the registry, the name and type of the IE are not known. Name is kept as an empty string. Type is always set to OctetArray. The length is known as it is included in the template record.

This change required adding support for the OctetArray type (fixed-length or variable-length).