### PR TITLE
Close TCP connection in case of error

### DIFF
--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -174,7 +174,7 @@ func (cp *CollectingProcess) Stop() {
 	close(cp.stopChan)
 	// wait for all connections to be safely deleted and returned
 	cp.wg.Wait()
-	klog.Info("Stopping the collecting process")
+	klog.Info("Stopped the collecting process")
 }
 
 func (cp *CollectingProcess) GetAddress() net.Addr {


### PR DESCRIPTION
This is better than keeping the connection open, as it sends a signal to the exporter that something is wrong.

This is also one of the four possible behaviors described by RFC7011 for handling malformed IPFIX messages for TCP and SCTP connections. See https://datatracker.ietf.org/doc/html/rfc7011#section-9.1. Note that implementing one of these four options is not mandatory. However, the RFC also states that:

> the Collecting Process SHOULD stop processing IPFIX Messages
> from clearly malfunctioning Exporting Processes (e.g., those from
> which the last few IPFIX Messages have been malformed).

Closing the TCP connection is the easiest thing for us to implement, and it makes sense to use IMO.