### PR TITLE
Manage templates per session instead of globally

### DIFF
--- a/pkg/collector/clock.go
+++ b/pkg/collector/clock.go
@@ -20,7 +20,7 @@ import (
 )
 
 // timer allows for injecting fake or real timers into code that needs to do arbitrary things based
-// on time. We do not include the C() method, as we only support timers created with AfterFunc.
+// on time.
 type timer interface {
 	C() <-chan time.Time
 	Stop() bool

--- a/pkg/collector/clock_test.go
+++ b/pkg/collector/clock_test.go
@@ -60,3 +60,67 @@ func TestFakeAfterFunc(t *testing.T) {
 		t.Fatalf("timer didn't fire")
 	}
 }
+
+func TestFakeNewTimer(t *testing.T) {
+	start := time.Now()
+	f := newFakeClock(start)
+	ch := make(chan time.Time, 1)
+	timer := f.NewTimer(1 * time.Second)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				return
+			case t := <-timer.C():
+				ch <- t
+			}
+		}
+	}()
+	// After 1s, the timer should fire.
+	f.Step(1 * time.Second)
+	select {
+	case v := <-ch:
+		assert.Equal(t, start.Add(1*time.Second), v)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timer didn't fire")
+	}
+	assert.False(t, timer.Stop(), "Stop should return false as timer has already been expired")
+	// After resetting the timer, it should fire again after another 1s.
+	assert.False(t, timer.Reset(1*time.Second), "Reset should return false as timer had expired")
+	f.Step(1 * time.Second)
+	select {
+	case v := <-ch:
+		assert.Equal(t, start.Add(2*time.Second), v)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timer didn't fire")
+	}
+
+	assert.False(t, timer.Reset(1*time.Second), "Reset should return false as timer had expired")
+	assert.True(t, timer.Stop(), "Stop should return true as call stops the timer")
+	assert.False(t, timer.Stop(), "Stop should return false as timer has already been stopped")
+	assert.False(t, timer.Reset(1*time.Second), "Reset should return false as timer had been stopped")
+
+	// The timer should not fire until the target time is reached.
+	f.Step(999 * time.Millisecond)
+	select {
+	case <-ch:
+		t.Fatalf("timer should not have fired")
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.True(t, timer.Reset(1*time.Second), "Reset should return true as timer had been active")
+	f.Step(1 * time.Millisecond)
+	select {
+	case <-ch:
+		t.Fatalf("timer should not have fired")
+	case <-time.After(100 * time.Millisecond):
+	}
+	f.Step(999 * time.Millisecond)
+	select {
+	case v := <-ch:
+		assert.Equal(t, start.Add(3999*time.Millisecond), v)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timer didn't fire")
+	}
+}

--- a/pkg/collector/session.go
+++ b/pkg/collector/session.go
@@ -1,0 +1,148 @@
+// Copyright 2024 VMware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/vmware/go-ipfix/pkg/entities"
+)
+
+type transportSession struct {
+	protocol string
+	id       string
+	mutex    sync.RWMutex
+	// for each obsDomainID, there is a map of templates (indexed by templateID)
+	templatesMap map[uint32]map[uint16]*template
+
+	// these fields are used for UDP packet handling
+	packetChan       chan *bytes.Buffer
+	closeSessionChan chan struct{}
+}
+
+func newUDPSession(id string) *transportSession {
+	return &transportSession{
+		protocol:         "udp",
+		id:               id,
+		templatesMap:     make(map[uint32]map[uint16]*template),
+		packetChan:       make(chan *bytes.Buffer),
+		closeSessionChan: make(chan struct{}),
+	}
+}
+
+func newTCPSession(id string) *transportSession {
+	return &transportSession{
+		protocol:     "tcp",
+		id:           id,
+		templatesMap: make(map[uint32]map[uint16]*template),
+	}
+}
+
+func (s *transportSession) addTemplate(clock clock, obsDomainID uint32, templateID uint16, elementsWithValue []entities.InfoElementWithValue, templateTTL time.Duration) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if _, ok := s.templatesMap[obsDomainID]; !ok {
+		s.templatesMap[obsDomainID] = make(map[uint16]*template)
+	}
+	elements := make([]*entities.InfoElement, 0)
+	for _, elementWithValue := range elementsWithValue {
+		elements = append(elements, elementWithValue.GetInfoElement())
+	}
+	tpl, ok := s.templatesMap[obsDomainID][templateID]
+	if !ok {
+		tpl = &template{}
+		s.templatesMap[obsDomainID][templateID] = tpl
+	}
+	tpl.ies = elements
+	klog.V(4).InfoS("Added template to template map", "obsDomainID", obsDomainID, "templateID", templateID)
+	// Template lifetime management for UDP.
+	if s.protocol != "udp" {
+		return
+	}
+	tpl.expiryTime = clock.Now().Add(templateTTL)
+	if tpl.expiryTimer == nil {
+		tpl.expiryTimer = clock.AfterFunc(templateTTL, func() {
+			klog.Infof("Template with id %d, and obsDomainID %d is expired.", templateID, obsDomainID)
+			now := clock.Now()
+			// From the Go documentation:
+			//   For a func-based timer created with AfterFunc(d, f), Reset either
+			//   reschedules when f will run, in which case Reset returns true, or
+			//   schedules f to run again, in which case it returns false. When Reset
+			//   returns false, Reset neither waits for the prior f to complete before
+			//   returning nor does it guarantee that the subsequent goroutine running f
+			//   does not run concurrently with the prior one. If the caller needs to
+			//   know whether the prior execution of f is completed, it must coordinate
+			//   with f explicitly.
+			// In our case, when f executes, we have to verify that the record is indeed
+			// scheduled for deletion by checking expiryTime. We cannot just
+			// automatically delete the template.
+			s.deleteTemplateWithConds(obsDomainID, templateID, func(tpl *template) bool {
+				// lock will be held when this executes
+				return !tpl.expiryTime.After(now)
+			})
+		})
+	} else {
+		tpl.expiryTimer.Reset(templateTTL)
+	}
+}
+
+// deleteTemplate returns true iff a template was actually deleted.
+func (s *transportSession) deleteTemplate(obsDomainID uint32, templateID uint16) bool {
+	return s.deleteTemplateWithConds(obsDomainID, templateID)
+}
+
+// deleteTemplateWithConds returns true iff a template was actually deleted.
+func (s *transportSession) deleteTemplateWithConds(obsDomainID uint32, templateID uint16, condFns ...func(*template) bool) bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	template, ok := s.templatesMap[obsDomainID][templateID]
+	if !ok {
+		return false
+	}
+	for _, condFn := range condFns {
+		if !condFn(template) {
+			return false
+		}
+	}
+	// expiryTimer will be nil when the protocol is TS.
+	if template.expiryTimer != nil {
+		// expiryTimer may have been stopped already (if the timer
+		// expired and is the reason why the template is being deleted),
+		// but it is safe to call Stop() on an expired timer.
+		template.expiryTimer.Stop()
+	}
+	delete(s.templatesMap[obsDomainID], templateID)
+	klog.V(4).InfoS("Deleted template from template map", "obsDomainID", obsDomainID, "templateID", templateID)
+	if len(s.templatesMap[obsDomainID]) == 0 {
+		delete(s.templatesMap, obsDomainID)
+		klog.V(4).InfoS("No more templates for observation domain", "obsDomainID", obsDomainID)
+	}
+	return true
+}
+
+func (s *transportSession) getTemplateIEs(obsDomainID uint32, templateID uint16) ([]*entities.InfoElement, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	if template, ok := s.templatesMap[obsDomainID][templateID]; ok {
+		return template.ies, nil
+	} else {
+		return nil, fmt.Errorf("template %d with obsDomainID %d does not exist", templateID, obsDomainID)
+	}
+}

--- a/pkg/collector/session_test.go
+++ b/pkg/collector/session_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 VMware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionTemplateAddAndDelete(t *testing.T) {
+	const (
+		templateID  = 100
+		obsDomainID = 0xabcd
+		templateTTL = 1 * time.Second
+	)
+	clock := newFakeClock(time.Now())
+	session := newUDPSession("foo")
+	session.addTemplate(clock, obsDomainID, templateID, elementsWithValueIPv4, templateTTL)
+	// Get a copy of the stored template
+	tpl := func() template {
+		session.mutex.RLock()
+		defer session.mutex.RUnlock()
+		return *session.templatesMap[obsDomainID][templateID]
+	}()
+	require.NotNil(t, tpl.expiryTimer)
+	require.True(t, session.deleteTemplate(obsDomainID, templateID))
+	// Stop returns false if the timer has already been stopped, which
+	// should be done by the call to deleteTemplate.
+	assert.False(t, tpl.expiryTimer.Stop())
+	// Deleting the template a second time should return false
+	assert.False(t, session.deleteTemplate(obsDomainID, templateID))
+}
+
+// TestSessionTemplateUpdate checks the behavior of addTemplate when a template is refreshed.
+func TestSessionTemplateUpdate(t *testing.T) {
+	const (
+		templateID  = 100
+		obsDomainID = 0xabcd
+		templateTTL = 1 * time.Second
+	)
+	now := time.Now()
+	clock := newFakeClock(now)
+	session := newUDPSession("foo")
+	session.addTemplate(clock, obsDomainID, templateID, elementsWithValueIPv4, templateTTL)
+	// Get a copy of the stored template
+	getTemplate := func() template {
+		session.mutex.RLock()
+		defer session.mutex.RUnlock()
+		return *session.templatesMap[obsDomainID][templateID]
+	}
+	tpl := getTemplate()
+	require.NotNil(t, tpl.expiryTimer)
+	assert.Equal(t, now.Add(templateTTL), tpl.expiryTime)
+	// Advance the clock by half the TTL
+	clock.Step(500 * time.Millisecond)
+	// Template should still be present in map
+	_, err := session.getTemplateIEs(obsDomainID, templateID)
+	require.NoError(t, err)
+	// "Update" the template (template is being refreshed)
+	session.addTemplate(clock, obsDomainID, templateID, elementsWithValueIPv4, templateTTL)
+	tpl = getTemplate()
+	assert.Equal(t, clock.Now().Add(templateTTL), tpl.expiryTime)
+	// Advance the clock by half the TTL again, template should still be present
+	clock.Step(500 * time.Millisecond)
+	_, err = session.getTemplateIEs(obsDomainID, templateID)
+	require.NoError(t, err)
+	// Advance the clock by half the TTL again, template should be expired
+	clock.Step(500 * time.Millisecond)
+	_, err = session.getTemplateIEs(obsDomainID, templateID)
+	assert.Error(t, err)
+}
+
+func BenchmarkAddTemplateUDP(b *testing.B) {
+	const (
+		templateID  = 100
+		templateTTL = 300 * time.Second
+	)
+	clock := newFakeClock(time.Now())
+	obsDomainID := uint32(1)
+	session := newUDPSession("foo")
+	b.ResetTimer()
+	for range b.N {
+		session.addTemplate(clock, obsDomainID, 256, elementsWithValueIPv4, templateTTL)
+		obsDomainID = (obsDomainID + 1) % 1000
+	}
+}


### PR DESCRIPTION
As per the IPFIX specification, a template is specific to a transport session. Observation domains are not guaranteed to be unique across transport sessions.

When a transport session is closed (TCP connection closed or UDP session timeout), all associated templates are removed. Note that prior to this change, templates associated to a TCP connection were never cleaned up, causing a memory leak.