### PR TITLE
Remove CloseMsgChan() method from collector process

### DIFF
--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -166,6 +166,8 @@ func (cp *CollectingProcess) Stop() {
 	close(cp.stopChan)
 	// wait for all connections to be safely deleted and returned
 	cp.wg.Wait()
+	// the message channel can only be closed AFTER all goroutines have returned
+	close(cp.messageChan)
 	klog.Info("Stopped the collecting process")
 }
 
@@ -177,10 +179,6 @@ func (cp *CollectingProcess) GetAddress() net.Addr {
 
 func (cp *CollectingProcess) GetMsgChan() <-chan *entities.Message {
 	return cp.messageChan
-}
-
-func (cp *CollectingProcess) CloseMsgChan() {
-	close(cp.messageChan)
 }
 
 func (cp *CollectingProcess) GetNumRecordsReceived() int64 {

--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -371,7 +371,6 @@ func TestUDPCollectingProcess_DecodePacketError(t *testing.T) {
 		t.Errorf("UDP Address cannot be resolved.")
 	}
 
-	defer cp.CloseMsgChan()
 	go func() {
 		// consume all messages to avoid blocking
 		ch := cp.GetMsgChan()

--- a/pkg/test/collector_producer_test.go
+++ b/pkg/test/collector_producer_test.go
@@ -52,12 +52,10 @@ var (
 )
 
 func TestCollectorToProducer(t *testing.T) {
-	address, err := net.ResolveUDPAddr("udp", "0.0.0.0:4739")
-	require.NoError(t, err)
 	// Initialize collecting process
 	cpInput := collector.CollectorInput{
-		Address:       address.String(),
-		Protocol:      address.Network(),
+		Address:       "127.0.0.1:0",
+		Protocol:      "udp",
 		MaxBufferSize: 1024,
 		TemplateTTL:   0,
 		IsEncrypted:   false,
@@ -84,6 +82,9 @@ func TestCollectorToProducer(t *testing.T) {
 
 	go cp.Start()
 	waitForCollectorReady(t, cp)
+	collectorAddr := cp.GetAddress()
+	address, err := net.ResolveUDPAddr(collectorAddr.Network(), collectorAddr.String())
+	require.NoError(t, err)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {

--- a/pkg/test/exporter_collector_test.go
+++ b/pkg/test/exporter_collector_test.go
@@ -171,7 +171,7 @@ func testExporterToCollector(address net.Addr, isSrcNode, isIPv6 bool, isMultipl
 		messages[messageIdx] = message
 		messageIdx++
 		if messageIdx == 2 {
-			cp.CloseMsgChan()
+			break
 		}
 	}
 	cp.Stop() // Close collecting process


### PR DESCRIPTION
Having a seprate method to close an "output" channel is an anti-pattern IMO, and it is not clear how library consumers are supposed to use it, in particular in relation to the Stop() method.

Instead, we can close the channel when the Stop() method is closed, and all goroutines which may write to the channel have been stopped. Goroutines which read from the channel can use this as a signal to stop - or can be signalled directly by the goroutine which called Stop() in the first place.