### PR TITLE
Improve IPFIX Set implementation

### DIFF
--- a/pkg/entities/record.go
+++ b/pkg/entities/record.go
@@ -41,6 +41,7 @@ type Record interface {
 	GetRecordLength() int
 	GetMinDataRecordLen() uint16
 	GetElementMap() map[string]interface{}
+	GetRecordType() ContentType
 }
 
 type baseRecord struct {
@@ -235,6 +236,10 @@ func (d *dataRecord) AddInfoElement(element InfoElementWithValue) error {
 	return nil
 }
 
+func (d *dataRecord) GetRecordType() ContentType {
+	return Data
+}
+
 func (t *templateRecord) PrepareRecord() error {
 	// Add Template Record Header
 	binary.BigEndian.PutUint16(t.buffer[0:2], t.templateID)
@@ -286,4 +291,8 @@ func (t *templateRecord) GetRecordLength() int {
 
 func (t *templateRecord) GetMinDataRecordLen() uint16 {
 	return t.minDataRecLength
+}
+
+func (d *templateRecord) GetRecordType() ContentType {
+	return Template
 }

--- a/pkg/entities/set.go
+++ b/pkg/entities/set.go
@@ -46,7 +46,7 @@ const (
 
 type Set interface {
 	PrepareSet(setType ContentType, templateID uint16) error
-	// Call ResetSet followd by a new call to PrepareSet in order to reuse an existing Set,
+	// Call ResetSet followed by a new call to PrepareSet in order to reuse an existing Set,
 	// instead of instantiating a new one.
 	ResetSet()
 	GetHeaderBuffer() []byte
@@ -108,7 +108,9 @@ func (s *set) PrepareSet(setType ContentType, templateID uint16) error {
 }
 
 func (s *set) ResetSet() {
-	if !s.isDecoding {
+	if s.isDecoding {
+		s.length = 0
+	} else {
 		clear(s.headerBuffer)
 		s.length = SetHeaderLen
 	}
@@ -189,10 +191,10 @@ func (s *set) AddRecordV3(record Record) error {
 	// Sanity check: we need to make sure that the record is allowed to be added.
 	recordType := record.GetRecordType()
 	if recordType != s.setType {
-		return fmt.Errorf("Record and Set types don't match")
+		return fmt.Errorf("record and set types don't match")
 	}
 	if recordType == Data && record.GetTemplateID() != s.templateID {
-		return fmt.Errorf("All Data Records in the same Data Set must have the same template ID")
+		return fmt.Errorf("all data records in the same data set must have the same template ID")
 	}
 	s.records = append(s.records, record)
 	s.length += record.GetRecordLength()

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -166,6 +166,20 @@ func (mr *MockRecordMockRecorder) GetRecordLength() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecordLength", reflect.TypeOf((*MockRecord)(nil).GetRecordLength))
 }
 
+// GetRecordType mocks base method.
+func (m *MockRecord) GetRecordType() entities.ContentType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRecordType")
+	ret0, _ := ret[0].(entities.ContentType)
+	return ret0
+}
+
+// GetRecordType indicates an expected call of GetRecordType.
+func (mr *MockRecordMockRecorder) GetRecordType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecordType", reflect.TypeOf((*MockRecord)(nil).GetRecordType))
+}
+
 // GetTemplateID mocks base method.
 func (m *MockRecord) GetTemplateID() uint16 {
 	m.ctrl.T.Helper()

--- a/pkg/entities/testing/mock_set.go
+++ b/pkg/entities/testing/mock_set.go
@@ -80,6 +80,20 @@ func (mr *MockSetMockRecorder) AddRecordV2(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRecordV2", reflect.TypeOf((*MockSet)(nil).AddRecordV2), arg0, arg1)
 }
 
+// AddRecordV3 mocks base method.
+func (m *MockSet) AddRecordV3(arg0 entities.Record) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddRecordV3", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddRecordV3 indicates an expected call of AddRecordV3.
+func (mr *MockSetMockRecorder) AddRecordV3(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRecordV3", reflect.TypeOf((*MockSet)(nil).AddRecordV3), arg0)
+}
+
 // AddRecordWithExtraElements mocks base method.
 func (m *MockSet) AddRecordWithExtraElements(arg0 []entities.InfoElementWithValue, arg1 int, arg2 uint16) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
* Optimize ResetSet to avoid memory allocations
* Add new interface method AddRecordV3 which takes a Record as a parameter (instead of a list of IEs). AddRecordV3 can avoid all memory allocations.

We also add a new GetRecordType method to the Record interface.