### PR TITLE
Add SendDataRecords to IPFIX Exporter

### DIFF
--- a/pkg/entities/message.go
+++ b/pkg/entities/message.go
@@ -19,8 +19,10 @@ import (
 )
 
 const (
-	MaxSocketMsgSize int = 65535
-	MsgHeaderLength  int = 16
+	MaxSocketMsgSize = 65535
+	MsgHeaderLength  = 16
+	// Typically all networks should support a datagram size of 512B without fragmentation.
+	MinSupportedMsgSize = 512
 )
 
 // Message represents IPFIX message.


### PR DESCRIPTION
As a more efficient and covenient alternative to SendSet.

* SendDataRecords takes a list of data Records (for the same template ID), and breaks them up into multiple IPFIX messages (with one data Set per message) as needed.
* SendDataRecords can take a reusable buffer as a parameter, to avoid repeated memory allocations.

We also introduce the MaxMsgSize input for the Exporter. It will be used by SendDataRecords to determine how to break up the list of Records into multiple messages. When using UDP, MaxMsgSize should be set based on the PMTU (Path MTU) to avoid fragmentation.