### PR TITLE
Support configurable decoding mode in reference collector program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,12 @@ golangci-fix: $(GOLANGCI_LINT_BIN)
 .PHONY: collector
 collector:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) github.com/vmware/go-ipfix/cmd/collector/
+	$(GO) build -o $(BINDIR) github.com/vmware/go-ipfix/cmd/collector/
 
 .PHONY: consumer
 consumer:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) github.com/vmware/go-ipfix/cmd/consumer/
+	$(GO) build -o $(BINDIR) github.com/vmware/go-ipfix/cmd/consumer/
 
 ### Docker images ###
 


### PR DESCRIPTION
By introducing the "--decoding-mode" flag.

LenientKeepUnknown can be used in order to accept templates with unknown IEs. Note that these IEs will be skipped when serializing data records.