### PR TITLE
Prevent unnecessary memory allocations in WriteIPFIXMsgToBuffer

### DIFF
--- a/pkg/entities/message.go
+++ b/pkg/entities/message.go
@@ -123,6 +123,5 @@ func (m *Message) GetMsgHeader() []byte {
 }
 
 func (m *Message) ResetMsgHeader() {
-	m.msgHeader = nil
-	m.msgHeader = make([]byte, MsgHeaderLength)
+	clear(m.msgHeader)
 }

--- a/pkg/entities/record.go
+++ b/pkg/entities/record.go
@@ -17,8 +17,6 @@ package entities
 import (
 	"encoding/binary"
 	"fmt"
-
-	"k8s.io/klog/v2"
 )
 
 //go:generate mockgen -copyright_file ../../license_templates/license_header.raw.txt -destination=testing/mock_record.go -package=testing github.com/vmware/go-ipfix/pkg/entities Record
@@ -33,7 +31,8 @@ type Record interface {
 	PrepareRecord() error
 	AddInfoElement(element InfoElementWithValue) error
 	// TODO: Functions for multiple elements as well.
-	GetBuffer() []byte
+	GetBuffer() ([]byte, error)
+	AppendToBuffer(buffer []byte) ([]byte, error)
 	GetTemplateID() uint16
 	GetFieldCount() uint16
 	GetOrderedElementList() []InfoElementWithValue
@@ -203,20 +202,31 @@ func (d *dataRecord) PrepareRecord() error {
 	return nil
 }
 
-func (d *dataRecord) GetBuffer() []byte {
+func (d *dataRecord) GetBuffer() ([]byte, error) {
 	if len(d.buffer) == d.len || d.isDecoding {
-		return d.buffer
+		return d.buffer, nil
 	}
 	d.buffer = make([]byte, d.len)
 	index := 0
 	for _, element := range d.orderedElementList {
-		err := encodeInfoElementValueToBuff(element, d.buffer, index)
-		if err != nil {
-			klog.Error(err)
+		if err := encodeInfoElementValueToBuff(element, d.buffer, index); err != nil {
+			return nil, err
 		}
 		index += element.GetLength()
 	}
-	return d.buffer
+	return d.buffer, nil
+}
+
+// Callers should ensure that the provided slice has enough capacity (e.g., by calling
+// GetRecordLength), in order to avoid memory allocations.
+func (d *dataRecord) AppendToBuffer(buffer []byte) ([]byte, error) {
+	var err error
+	for _, element := range d.orderedElementList {
+		if buffer, err = appendInfoElementValueToBuffer(element, buffer); err != nil {
+			return nil, err
+		}
+	}
+	return buffer, nil
 }
 
 func (d *dataRecord) GetRecordLength() int {
@@ -281,8 +291,12 @@ func (t *templateRecord) AddInfoElement(element InfoElementWithValue) error {
 	return nil
 }
 
-func (t *templateRecord) GetBuffer() []byte {
-	return t.buffer
+func (t *templateRecord) GetBuffer() ([]byte, error) {
+	return t.buffer, nil
+}
+
+func (t *templateRecord) AppendToBuffer(buffer []byte) ([]byte, error) {
+	return append(buffer, t.buffer...), nil
 }
 
 func (t *templateRecord) GetRecordLength() int {

--- a/pkg/entities/record_test.go
+++ b/pkg/entities/record_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var uniqueTemplateID uint16 = 256
@@ -139,10 +140,12 @@ func TestAddInfoElements(t *testing.T) {
 			assert.Equal(t, nil, actualErr, "Error returned is not nil")
 		}
 		// go test -v to see data buffer in hex format
+		buf, err := test.record.GetBuffer()
+		require.NoError(t, err)
 		if i == 0 {
-			t.Logf("template record %x", test.record.GetBuffer())
+			t.Logf("template record %x", buf)
 		} else {
-			t.Logf("data record %x", test.record.GetBuffer())
+			t.Logf("data record %x", buf)
 		}
 	}
 }

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -70,7 +70,10 @@ func testAddRecordIPAddresses(t testing.TB, isIPv6 bool) {
 	expectedBuf := make([]byte, 0, len(ip1)+len(ip2))
 	expectedBuf = append(expectedBuf, ip1...)
 	expectedBuf = append(expectedBuf, ip2...)
-	assert.Equal(t, expectedBuf, newSet.GetRecords()[0].GetBuffer())
+	require.Len(t, newSet.GetRecords(), 1)
+	buf, err := newSet.GetRecords()[0].GetBuffer()
+	require.NoError(t, err)
+	assert.Equal(t, expectedBuf, buf)
 }
 
 func TestAddRecordIPAddresses(t *testing.T) {

--- a/pkg/entities/testing/mock_record.go
+++ b/pkg/entities/testing/mock_record.go
@@ -66,12 +66,28 @@ func (mr *MockRecordMockRecorder) AddInfoElement(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInfoElement", reflect.TypeOf((*MockRecord)(nil).AddInfoElement), arg0)
 }
 
+// AppendToBuffer mocks base method.
+func (m *MockRecord) AppendToBuffer(arg0 []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppendToBuffer", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AppendToBuffer indicates an expected call of AppendToBuffer.
+func (mr *MockRecordMockRecorder) AppendToBuffer(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendToBuffer", reflect.TypeOf((*MockRecord)(nil).AppendToBuffer), arg0)
+}
+
 // GetBuffer mocks base method.
-func (m *MockRecord) GetBuffer() []byte {
+func (m *MockRecord) GetBuffer() ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBuffer")
 	ret0, _ := ret[0].([]byte)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetBuffer indicates an expected call of GetBuffer.

--- a/pkg/exporter/msg_test.go
+++ b/pkg/exporter/msg_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 VMware, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/go-ipfix/pkg/entities"
+	"github.com/vmware/go-ipfix/pkg/registry"
+)
+
+func BenchmarkWriteIPFIXMsgToBuffer(b *testing.B) {
+	now := time.Now()
+	const templateID = 256
+	ieSrc, err := registry.GetInfoElement("sourceIPv4Address", registry.IANAEnterpriseID)
+	require.NoError(b, err, "Did not find the element with name sourceIPv4Address")
+	ieDst, err := registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
+	require.NoError(b, err, "Did not find the element with name destinationIPv4Address")
+	getDataRecord := func() entities.Record {
+		elements := []entities.InfoElementWithValue{
+			entities.NewIPAddressInfoElement(ieSrc, net.ParseIP("1.2.3.4")),
+			entities.NewIPAddressInfoElement(ieDst, net.ParseIP("5.6.7.8")),
+		}
+		return entities.NewDataRecordFromElements(templateID, elements, false)
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, 512))
+	b.ResetTimer()
+
+	for range b.N {
+		b.StopTimer()
+		dataSet := entities.NewSet(false)
+		require.NoError(b, dataSet.PrepareSet(entities.Data, templateID))
+		// 10 records in one data set / message seems like a reasonable benchmark.
+		const numRecords = 10
+		for range numRecords {
+			require.NoError(b, dataSet.AddRecordV3(getDataRecord()))
+		}
+		buf.Reset()
+		b.StartTimer()
+		n, err := WriteIPFIXMsgToBuffer(dataSet, 1, 1, now, buf)
+		require.NoError(b, err)
+		assert.Greater(b, n, 0)
+	}
+}

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -549,7 +549,8 @@ func (ep *ExportingProcess) dataRecSanityCheck(rec entities.Record) error {
 	if rec.GetFieldCount() != uint16(len(ep.templatesMap[templateID].elements)) {
 		return fmt.Errorf("process: field count of data does not match templateID %d", templateID)
 	}
-	if len(rec.GetBuffer()) < int(ep.templatesMap[templateID].minDataRecLen) {
+
+	if rec.GetRecordLength() < int(ep.templatesMap[templateID].minDataRecLen) {
 		return fmt.Errorf("process: Data Record does not pass the min required length (%d) check for template ID %d", ep.templatesMap[templateID].minDataRecLen, templateID)
 	}
 	return nil

--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -278,7 +278,7 @@ func TestExportingProcess_SendingDataRecordToLocalTCPServer(t *testing.T) {
 	elements = append(elements, ie)
 
 	dataSet.AddRecord(elements, templateID)
-	dataRecBuff := dataSet.GetRecords()[0].GetBuffer()
+	dataRecBuff, _ := dataSet.GetRecords()[0].GetBuffer()
 
 	bytesSent, err := exporter.SendSet(dataSet)
 	assert.NoError(t, err)
@@ -379,7 +379,7 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	elements = append(elements, ie)
 
 	dataSet.AddRecord(elements, templateID)
-	dataRecBuff := dataSet.GetRecords()[0].GetBuffer()
+	dataRecBuff, _ := dataSet.GetRecords()[0].GetBuffer()
 
 	bytesSent, err := exporter.SendSet(dataSet)
 	assert.NoError(t, err)
@@ -854,7 +854,7 @@ func TestSendDataRecords(t *testing.T) {
 	getDataRecord := func() entities.Record {
 		elements := []entities.InfoElementWithValue{
 			entities.NewIPAddressInfoElement(ieSrc, net.ParseIP("1.2.3.4")),
-			entities.NewIPAddressInfoElement(ieSrc, net.ParseIP("5.6.7.8")),
+			entities.NewIPAddressInfoElement(ieDst, net.ParseIP("5.6.7.8")),
 		}
 		return entities.NewDataRecordFromElements(templateID, elements, false)
 	}


### PR DESCRIPTION
Calling GetBuffer on a record allocates a new buffer which is then copied to the message buffer. This is not necessary as we can directly encode the IE value to the message buffer.
The recommended way to do that is to call AvailableBuffer on the bytes.Buffer object to get a []byte buffer with enough capacity, then call Append-style methods to add data to the buffer (without allocating new memory).