### PR TITLE
Do not embed Record interface into baseRecord

### DIFF
--- a/pkg/entities/record.go
+++ b/pkg/entities/record.go
@@ -51,7 +51,6 @@ type baseRecord struct {
 	orderedElementList []InfoElementWithValue
 	isDecoding         bool
 	len                int
-	Record
 }
 
 type dataRecord struct {
@@ -234,6 +233,11 @@ func (d *dataRecord) AddInfoElement(element InfoElementWithValue) error {
 	}
 	d.fieldCount++
 	return nil
+}
+
+// This method is only meaningful for template records.
+func (d *dataRecord) GetMinDataRecordLen() uint16 {
+	return 0
 }
 
 func (d *dataRecord) GetRecordType() ContentType {


### PR DESCRIPTION
As far as I know this is an anti-pattern, and I am not sure why it was done this way. baseRecord is just here to help reduce code duplication in dataRecord and templateRecord, which both implement the Record interface.

When embedding Recod in baseRecord, we 1) obfuscate things, making it harder to detect at compile time that one of the record types is missing a method implementation, and 2) increase the size of the baseRecord struct needlessly (after this change the size is reduced from 88B down to 72B on my machine).