### PR TITLE
Improve collector program for data sets with multiple records

### DIFF
--- a/cmd/collector/collector_test.go
+++ b/cmd/collector/collector_test.go
@@ -15,12 +15,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +29,21 @@ import (
 	"github.com/vmware/go-ipfix/pkg/entities"
 )
 
-var testFlowRecords = []string{"flow1", "flow2", "flow3"}
+const templateID = 256
+
+var (
+	flow1 = &flowRecord{
+		Data: "flow1",
+	}
+	flow2 = &flowRecord{
+		Data: "flow2",
+	}
+	flow3 = &flowRecord{
+		Data: "flow3",
+	}
+)
+
+var testFlowRecords = []*flowRecord{flow1, flow2, flow3}
 
 func TestFlowRecordHandler(t *testing.T) {
 	flowRecords = testFlowRecords
@@ -42,31 +56,31 @@ func TestFlowRecordHandler(t *testing.T) {
 		countParam     string
 		formatParam    string
 		expectedStatus int
-		expectedFlows  []string
+		expectedFlows  []*flowRecord
 	}{
 		{
 			name:          "default",
-			expectedFlows: []string{"flow1", "flow2", "flow3"},
+			expectedFlows: []*flowRecord{flow1, flow2, flow3},
 		},
 		{
 			name:          "last flow",
 			countParam:    "1",
-			expectedFlows: []string{"flow3"},
+			expectedFlows: []*flowRecord{flow3},
 		},
 		{
 			name:          "text format",
 			formatParam:   "text",
-			expectedFlows: []string{"flow1", "flow2", "flow3"},
+			expectedFlows: []*flowRecord{flow1, flow2, flow3},
 		},
 		{
 			name:          "json format",
 			formatParam:   "json",
-			expectedFlows: []string{"flow1", "flow2", "flow3"},
+			expectedFlows: []*flowRecord{flow1, flow2, flow3},
 		},
 		{
 			name:          "large count",
 			countParam:    "100",
-			expectedFlows: []string{"flow1", "flow2", "flow3"},
+			expectedFlows: []*flowRecord{flow1, flow2, flow3},
 		},
 		{
 			name:           "invalid count",
@@ -82,7 +96,7 @@ func TestFlowRecordHandler(t *testing.T) {
 			name:          "both params set",
 			countParam:    "2",
 			formatParam:   "text",
-			expectedFlows: []string{"flow2", "flow3"},
+			expectedFlows: []*flowRecord{flow2, flow3},
 		},
 	}
 
@@ -130,9 +144,11 @@ func TestFlowRecordHandler(t *testing.T) {
 				assert.Equal(t, tc.expectedFlows, data.FlowRecords)
 			} else if format == "text" {
 				require.Equal(t, "text/plain", contentType)
-				flows := strings.Split(string(body), string(flowTextSeparator))
-				// Ignore the last empty fragment.
-				assert.Equal(t, tc.expectedFlows, flows[:len(flows)-1])
+				expectedFlows := ""
+				for _, flow := range tc.expectedFlows {
+					expectedFlows += flow.Data + string(flowTextSeparator)
+				}
+				assert.Equal(t, expectedFlows, string(body))
 			} else {
 				require.FailNow(t, "Invalid format specified for test case")
 			}
@@ -144,13 +160,33 @@ func TestAddIPFIXMessage(t *testing.T) {
 	defer func() {
 		flowRecords = nil
 	}()
+	var buf bytes.Buffer
 	set := entities.NewSet(false)
+	require.NoError(t, set.PrepareSet(entities.Data, templateID))
+	require.NoError(t, set.AddRecord([]entities.InfoElementWithValue{}, templateID))
 	msg := entities.NewMessage(false)
 	msg.AddSet(set)
 	for i := 0; i < maxFlowRecords; i++ {
-		addIPFIXMessage(msg)
+		addIPFIXMessage(msg, &buf)
 		require.Len(t, flowRecords, i+1)
 	}
-	addIPFIXMessage(msg)
+	addIPFIXMessage(msg, &buf)
 	assert.Len(t, flowRecords, maxFlowRecords)
+}
+
+func TestAddIPFIXMessageMultipleDataRecords(t *testing.T) {
+	defer func() {
+		flowRecords = nil
+	}()
+	var buf bytes.Buffer
+	set := entities.NewSet(false)
+	require.NoError(t, set.PrepareSet(entities.Data, templateID))
+	require.NoError(t, set.AddRecord([]entities.InfoElementWithValue{}, templateID))
+	require.NoError(t, set.AddRecord([]entities.InfoElementWithValue{}, templateID))
+	msg := entities.NewMessage(false)
+	msg.AddSet(set)
+	addIPFIXMessage(msg, &buf)
+	require.Len(t, flowRecords, 2)
+	assert.EqualValues(t, 0, flowRecords[0].RecordIdx)
+	assert.EqualValues(t, 1, flowRecords[1].RecordIdx)
 }


### PR DESCRIPTION
When multiple data records are present in a set / IPFIX message, we need to "split" them so that the API returns them as individual records.

We also drop template records to simplify the implementation.