### PR TITLE
Fix Record length computation

### DIFF
--- a/pkg/entities/record.go
+++ b/pkg/entities/record.go
@@ -46,42 +46,30 @@ type Record interface {
 }
 
 type baseRecord struct {
-	buffer             []byte
 	fieldCount         uint16
 	templateID         uint16
 	orderedElementList []InfoElementWithValue
-	isDecoding         bool
-	len                int
 }
 
 type dataRecord struct {
 	baseRecord
 }
 
-func NewDataRecord(id uint16, numElements, numExtraElements int, isDecoding bool) *dataRecord {
+func NewDataRecord(id uint16, numElements, numExtraElements int) *dataRecord {
 	return &dataRecord{
 		baseRecord{
 			fieldCount:         0,
 			templateID:         id,
-			isDecoding:         isDecoding,
 			orderedElementList: make([]InfoElementWithValue, numElements, numElements+numExtraElements),
 		},
 	}
 }
 
-func NewDataRecordFromElements(id uint16, elements []InfoElementWithValue, isDecoding bool) *dataRecord {
-	length := 0
-	if !isDecoding {
-		for idx := range elements {
-			length += elements[idx].GetLength()
-		}
-	}
+func NewDataRecordFromElements(id uint16, elements []InfoElementWithValue) *dataRecord {
 	return &dataRecord{
 		baseRecord{
 			fieldCount:         uint16(len(elements)),
 			templateID:         id,
-			isDecoding:         isDecoding,
-			len:                length,
 			orderedElementList: elements,
 		},
 	}
@@ -92,35 +80,35 @@ type templateRecord struct {
 	// Minimum data record length required to be sent for this template.
 	// Elements with variable length are considered to be one byte.
 	minDataRecLength uint16
-	// index is used when adding elements to orderedElementList
+	// index is used when adding elements to orderedElementList.
 	index int
+	// buffer is used to marshal the template record.
+	buffer []byte
 }
 
-func NewTemplateRecord(id uint16, numElements int, isDecoding bool) *templateRecord {
+func NewTemplateRecord(id uint16, numElements int) *templateRecord {
 	return &templateRecord{
 		baseRecord{
-			buffer:             make([]byte, 4),
 			fieldCount:         uint16(numElements),
 			templateID:         id,
-			isDecoding:         isDecoding,
 			orderedElementList: make([]InfoElementWithValue, numElements, numElements),
 		},
 		0,
 		0,
+		make([]byte, 4),
 	}
 }
 
-func NewTemplateRecordFromElements(id uint16, elements []InfoElementWithValue, isDecoding bool) *templateRecord {
+func NewTemplateRecordFromElements(id uint16, elements []InfoElementWithValue) *templateRecord {
 	r := &templateRecord{
 		baseRecord{
-			buffer:             make([]byte, 4),
 			fieldCount:         uint16(len(elements)),
 			templateID:         id,
-			isDecoding:         isDecoding,
 			orderedElementList: elements,
 		},
 		0,
 		len(elements),
+		make([]byte, 4),
 	}
 	for idx := range elements {
 		infoElement := elements[idx].GetInfoElement()
@@ -204,18 +192,15 @@ func (d *dataRecord) PrepareRecord() error {
 }
 
 func (d *dataRecord) GetBuffer() ([]byte, error) {
-	if len(d.buffer) == d.len || d.isDecoding {
-		return d.buffer, nil
-	}
-	d.buffer = make([]byte, d.len)
+	buffer := make([]byte, d.GetRecordLength())
 	index := 0
 	for _, element := range d.orderedElementList {
-		if err := encodeInfoElementValueToBuff(element, d.buffer, index); err != nil {
+		if err := encodeInfoElementValueToBuff(element, buffer, index); err != nil {
 			return nil, err
 		}
 		index += element.GetLength()
 	}
-	return d.buffer, nil
+	return buffer, nil
 }
 
 // Callers should ensure that the provided slice has enough capacity (e.g., by calling
@@ -231,13 +216,14 @@ func (d *dataRecord) AppendToBuffer(buffer []byte) ([]byte, error) {
 }
 
 func (d *dataRecord) GetRecordLength() int {
-	return d.len
+	length := 0
+	for _, element := range d.orderedElementList {
+		length += element.GetLength()
+	}
+	return length
 }
 
 func (d *dataRecord) AddInfoElement(element InfoElementWithValue) error {
-	if !d.isDecoding {
-		d.len = d.len + element.GetLength()
-	}
 	if len(d.orderedElementList) <= int(d.fieldCount) {
 		d.orderedElementList = append(d.orderedElementList, element)
 	} else {

--- a/pkg/entities/record_test.go
+++ b/pkg/entities/record_test.go
@@ -31,8 +31,8 @@ func TestPrepareRecord(t *testing.T) {
 		expectLen uint16
 		expectErr error
 	}{
-		{NewDataRecord(uniqueTemplateID, 1, 0, false), 0, nil},
-		{NewTemplateRecord(uniqueTemplateID, 1, false), 4, nil},
+		{NewDataRecord(uniqueTemplateID, 1, 0), 0, nil},
+		{NewTemplateRecord(uniqueTemplateID, 1), 4, nil},
 	}
 
 	for _, test := range prepareRecordTests {
@@ -95,8 +95,8 @@ func TestAddInfoElements(t *testing.T) {
 		ieList  []*InfoElement
 		valList valData
 	}{
-		{NewTemplateRecord(uniqueTemplateID, 12, false), testIEs, valData{}},
-		{NewDataRecord(uniqueTemplateID, len(testIEs), 0, false), testIEs, values},
+		{NewTemplateRecord(uniqueTemplateID, 12), testIEs, valData{}},
+		{NewDataRecord(uniqueTemplateID, len(testIEs), 0), testIEs, values},
 	}
 
 	for i, test := range addIETests {
@@ -151,7 +151,7 @@ func TestAddInfoElements(t *testing.T) {
 }
 
 func TestGetInfoElementWithValue(t *testing.T) {
-	templateRec := NewTemplateRecord(256, 1, true)
+	templateRec := NewTemplateRecord(256, 1)
 	templateRec.orderedElementList = make([]InfoElementWithValue, 0)
 	ie := NewIPAddressInfoElement(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), nil)
 	templateRec.orderedElementList = append(templateRec.orderedElementList, ie)
@@ -159,7 +159,7 @@ func TestGetInfoElementWithValue(t *testing.T) {
 	assert.Equal(t, true, exist)
 	_, _, exist = templateRec.GetInfoElementWithValue("destinationIPv4Address")
 	assert.Equal(t, false, exist)
-	dataRec := NewDataRecord(256, 1, 0, true)
+	dataRec := NewDataRecord(256, 1, 0)
 	dataRec.orderedElementList = make([]InfoElementWithValue, 0)
 	ie = NewIPAddressInfoElement(NewInfoElement("sourceIPv4Address", 8, 18, 0, 4), net.ParseIP("10.0.0.1"))
 	dataRec.orderedElementList = append(dataRec.orderedElementList, ie)
@@ -216,7 +216,7 @@ func TestGetElementMap(t *testing.T) {
 		uint32(time.Now().Unix()),   // dateTimeSeconds
 		uint64(time.Now().Unix()),   // dateTimeMilliseconds
 	}
-	record := NewDataRecord(uniqueTemplateID, len(ieList), 0, false)
+	record := NewDataRecord(uniqueTemplateID, len(ieList), 0)
 
 	for _, testIE := range ieList {
 		var ie InfoElementWithValue

--- a/pkg/entities/set.go
+++ b/pkg/entities/set.go
@@ -148,9 +148,9 @@ func (s *set) AddRecord(elements []InfoElementWithValue, templateID uint16) erro
 func (s *set) AddRecordWithExtraElements(elements []InfoElementWithValue, numExtraElements int, templateID uint16) error {
 	var record Record
 	if s.setType == Data {
-		record = NewDataRecord(templateID, len(elements), numExtraElements, s.isDecoding)
+		record = NewDataRecord(templateID, len(elements), numExtraElements)
 	} else if s.setType == Template {
-		record = NewTemplateRecord(templateID, len(elements), s.isDecoding)
+		record = NewTemplateRecord(templateID, len(elements))
 		err := record.PrepareRecord()
 		if err != nil {
 			return err
@@ -172,9 +172,9 @@ func (s *set) AddRecordWithExtraElements(elements []InfoElementWithValue, numExt
 func (s *set) AddRecordV2(elements []InfoElementWithValue, templateID uint16) error {
 	var record Record
 	if s.setType == Data {
-		record = NewDataRecordFromElements(templateID, elements, s.isDecoding)
+		record = NewDataRecordFromElements(templateID, elements)
 	} else if s.setType == Template {
-		record = NewTemplateRecordFromElements(templateID, elements, s.isDecoding)
+		record = NewTemplateRecordFromElements(templateID, elements)
 		err := record.PrepareRecord()
 		if err != nil {
 			return err

--- a/pkg/entities/set_test.go
+++ b/pkg/entities/set_test.go
@@ -197,7 +197,6 @@ func BenchmarkSet(b *testing.B) {
 				NewIPAddressInfoElement(sourceIE, net.ParseIP(testIPv4Addr1)),
 				NewIPAddressInfoElement(destinationIE, net.ParseIP(testIPv4Addr2)),
 			},
-			false,
 		)
 	}
 

--- a/pkg/exporter/buffered_test.go
+++ b/pkg/exporter/buffered_test.go
@@ -70,7 +70,7 @@ func TestBufferedExporter(t *testing.T) {
 	ieDst, err := registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	require.NoError(t, err, "Did not find the element with name destinationIPv4Address")
 	elements = append(elements, entities.NewIPAddressInfoElement(ieDst, nil))
-	template := entities.NewTemplateRecordFromElements(templateID, elements, false)
+	template := entities.NewTemplateRecordFromElements(templateID, elements)
 	require.NoError(t, template.PrepareRecord())
 
 	require.NoError(t, bufferedExporter.AddRecord(template))
@@ -86,7 +86,7 @@ func TestBufferedExporter(t *testing.T) {
 			entities.NewIPAddressInfoElement(ieSrc, net.ParseIP("1.2.3.4")),
 			entities.NewIPAddressInfoElement(ieDst, net.ParseIP("5.6.7.8")),
 		}
-		return entities.NewDataRecordFromElements(templateID, elements, false)
+		return entities.NewDataRecordFromElements(templateID, elements)
 	}()
 	// Each record will be 8B. The message size has been set to 512B above.
 	// The overhead per message is 16 (message header) + 4 (set header).
@@ -149,7 +149,7 @@ func BenchmarkBufferedExporter(b *testing.B) {
 	ieDst, err := registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	require.NoError(b, err, "Did not find the element with name destinationIPv4Address")
 	elements = append(elements, entities.NewIPAddressInfoElement(ieDst, nil))
-	template := entities.NewTemplateRecordFromElements(templateID, elements, false)
+	template := entities.NewTemplateRecordFromElements(templateID, elements)
 	require.NoError(b, template.PrepareRecord())
 
 	require.NoError(b, bufferedExporter.AddRecord(template))
@@ -159,7 +159,7 @@ func BenchmarkBufferedExporter(b *testing.B) {
 			entities.NewIPAddressInfoElement(ieSrc, net.ParseIP("1.2.3.4")),
 			entities.NewIPAddressInfoElement(ieDst, net.ParseIP("5.6.7.8")),
 		}
-		return entities.NewDataRecordFromElements(templateID, elements, false)
+		return entities.NewDataRecordFromElements(templateID, elements)
 	}()
 
 	b.ResetTimer()
@@ -213,7 +213,7 @@ func TestBufferedExporter_UpdateTemplate(t *testing.T) {
 	ieDst, err := registry.GetInfoElement("destinationIPv4Address", registry.IANAEnterpriseID)
 	require.NoError(t, err, "Did not find the element with name destinationIPv4Address")
 	elements = append(elements, entities.NewIPAddressInfoElement(ieDst, nil))
-	template := entities.NewTemplateRecordFromElements(templateID, elements, false)
+	template := entities.NewTemplateRecordFromElements(templateID, elements)
 	require.NoError(t, template.PrepareRecord())
 
 	// msg header (16) + set header (4) + template record header (4) + 2 field specifiers (8)
@@ -259,7 +259,7 @@ func TestBufferedExporter_UpdateTemplate(t *testing.T) {
 			entities.NewIPAddressInfoElement(ieSrc, net.ParseIP("1.2.3.4")),
 			entities.NewIPAddressInfoElement(ieDst, net.ParseIP("5.6.7.8")),
 		}
-		return entities.NewDataRecordFromElements(templateID, elements, false)
+		return entities.NewDataRecordFromElements(templateID, elements)
 	}()
 
 	require.NoError(t, bufferedExporter.AddRecord(record))

--- a/pkg/exporter/msg_test.go
+++ b/pkg/exporter/msg_test.go
@@ -39,7 +39,7 @@ func BenchmarkWriteIPFIXMsgToBuffer(b *testing.B) {
 			entities.NewIPAddressInfoElement(ieSrc, net.ParseIP("1.2.3.4")),
 			entities.NewIPAddressInfoElement(ieDst, net.ParseIP("5.6.7.8")),
 		}
-		return entities.NewDataRecordFromElements(templateID, elements, false)
+		return entities.NewDataRecordFromElements(templateID, elements)
 	}
 	buf := bytes.NewBuffer(make([]byte, 0, 512))
 	b.ResetTimer()

--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -858,7 +858,7 @@ func TestSendDataRecords(t *testing.T) {
 			entities.NewIPAddressInfoElement(ieSrc, net.ParseIP("1.2.3.4")),
 			entities.NewIPAddressInfoElement(ieDst, net.ParseIP("5.6.7.8")),
 		}
-		return entities.NewDataRecordFromElements(templateID, elements, false)
+		return entities.NewDataRecordFromElements(templateID, elements)
 	}
 	// Each record will be 8B. The message size has been set to 512B above.
 	// The overheade per message is 16 (message header) + 4 (set header).


### PR DESCRIPTION
In several cases, GetRecordLength() was returning an invalid value:
- for "decoded" records, the method would always return 0.
- when mutating an IE value with a variable length (e.g., a string element), the cached record length would no longer be correct and the method would return an invalid value.

To avoid this issue, we stop caching the length as part of the Record object, and instead we recompute the length whenever GetRecordLength() is invoked. Typically, this method is only invoked once for a given Record, at the time of exporting the Record, so there should not be any performane impact in a real-life scenario.

We also remove the buffer field from DataRecord (we keep it for TemplateRecord), and we remove the isDecoding field for all records, as it was only used for length tracking and is confusing. For now, we do not modify the Set implementation, although in the long term we should remove isDecoding everywhere and use a standard Marshal / Unmarshal approach.