### PR TITLE
Fix sequence number incrementing in IPFIX exporter

### DIFF
--- a/pkg/exporter/buffered.go
+++ b/pkg/exporter/buffered.go
@@ -186,7 +186,6 @@ func encodeSetHeader(buf []byte, templateID, length uint16) {
 
 func (m *bufferedMessage) sendMessage() (int, error) {
 	now := time.Now()
-	m.ep.seqNumber = m.ep.seqNumber + uint32(m.numRecords)
 	msgLen := len(m.buffer)
 	encodeMessageHeader(m.buffer, 10, uint16(msgLen), uint32(now.Unix()), m.ep.seqNumber, m.ep.obsDomainID)
 	encodeSetHeader(m.buffer[entities.MsgHeaderLength:], m.templateID, uint16(msgLen-entities.MsgHeaderLength))
@@ -194,6 +193,7 @@ func (m *bufferedMessage) sendMessage() (int, error) {
 	if err != nil {
 		return n, err
 	}
+	m.ep.seqNumber = m.ep.seqNumber + uint32(m.numRecords)
 	m.reset()
 	return n, nil
 }

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -451,9 +451,6 @@ func (ep *ExportingProcess) NewTemplateID() uint16 {
 // createAndSendIPFIXMsg takes in a set as input, creates the IPFIX message, and sends it out.
 // TODO: This method will change when we support sending multiple sets.
 func (ep *ExportingProcess) createAndSendIPFIXMsg(set entities.Set, buf *bytes.Buffer) (int, error) {
-	if set.GetSetType() == entities.Data {
-		ep.seqNumber = ep.seqNumber + set.GetNumberOfRecords()
-	}
 	n, err := WriteIPFIXMsgToBuffer(set, ep.obsDomainID, ep.seqNumber, time.Now(), buf)
 	if err != nil {
 		return 0, err
@@ -469,6 +466,10 @@ func (ep *ExportingProcess) createAndSendIPFIXMsg(set entities.Set, buf *bytes.B
 		return bytesSent, fmt.Errorf("error when sending message on the connection: %v", err)
 	} else if bytesSent != n {
 		return bytesSent, fmt.Errorf("could not send the complete message on the connection")
+	}
+
+	if set.GetSetType() == entities.Data {
+		ep.seqNumber = ep.seqNumber + set.GetNumberOfRecords()
 	}
 
 	return bytesSent, nil


### PR DESCRIPTION
The sequence number should be the total number of IPFIX Data Records sent prior to the current message.