### PR TITLE
Support for more TLS config options in Collector and Exporter

### DIFF
--- a/pkg/collector/process.go
+++ b/pkg/collector/process.go
@@ -83,10 +83,12 @@ type CollectingProcess struct {
 	// decoding.
 	decodingMode DecodingMode
 	// caCert, serverCert and serverKey are for storing encryption info when using TLS/DTLS
-	caCert     []byte
-	serverCert []byte
-	serverKey  []byte
-	wg         sync.WaitGroup
+	caCert          []byte
+	serverCert      []byte
+	serverKey       []byte
+	tlsCipherSuites []uint16
+	tlsMinVersion   uint16
+	wg              sync.WaitGroup
 	// stats for IPFIX objects received
 	numOfMessagesReceived        uint64
 	numOfTemplateSetsReceived    uint64
@@ -108,9 +110,18 @@ type CollectorInput struct {
 	MaxBufferSize uint16
 	TemplateTTL   uint32
 	// TODO: group following fields into struct to be reuse in exporter
-	CACert           []byte
-	ServerCert       []byte
-	ServerKey        []byte
+	CACert     []byte
+	ServerCert []byte
+	ServerKey  []byte
+	// List of supported cipher suites.
+	// From https://pkg.go.dev/crypto/tls#pkg-constants
+	// The order of the list is ignored.Note that TLS 1.3 ciphersuites are not configurable.
+	// For DTLS, cipher suites are from https://pkg.go.dev/github.com/pion/dtls/v2@v2.2.12/internal/ciphersuite#ID.
+	TLSCipherSuites []uint16
+	// Min TLS version.
+	// From https://pkg.go.dev/crypto/tls#pkg-constants
+	// Not configurable for DTLS, as only DTLS 1.2 is supported.
+	TLSMinVersion    uint16
 	NumExtraElements int
 	// DecodingMode specifies how unknown information elements (in templates) are handled when
 	// decoding. The default value is DecodingModeStrict for historical reasons. For most uses,
@@ -146,6 +157,8 @@ func initCollectingProcess(input CollectorInput, clock clock) (*CollectingProces
 		caCert:           input.CACert,
 		serverCert:       input.ServerCert,
 		serverKey:        input.ServerKey,
+		tlsCipherSuites:  input.TLSCipherSuites,
+		tlsMinVersion:    input.TLSMinVersion,
 		numExtraElements: input.NumExtraElements,
 		decodingMode:     decodingMode,
 		clock:            clock,

--- a/pkg/collector/tcp.go
+++ b/pkg/collector/tcp.go
@@ -16,7 +16,7 @@ import (
 func (cp *CollectingProcess) startTCPServer() {
 	var listener net.Listener
 	if cp.isEncrypted { // use TLS
-		config, err := cp.createServerConfig()
+		config, err := cp.createServerTLSConfig()
 		if err != nil {
 			klog.Error(err)
 			return
@@ -133,7 +133,7 @@ func (cp *CollectingProcess) handleTCPClient(conn net.Conn) {
 	}
 }
 
-func (cp *CollectingProcess) createServerConfig() (*tls.Config, error) {
+func (cp *CollectingProcess) createServerTLSConfig() (*tls.Config, error) {
 	cert, err := tls.X509KeyPair(cp.serverCert, cp.serverKey)
 	if err != nil {
 		return nil, err
@@ -153,12 +153,12 @@ func (cp *CollectingProcess) createServerConfig() (*tls.Config, error) {
 	if cp.caCert == nil {
 		return tlsConfig, nil
 	}
-	roots := x509.NewCertPool()
-	ok := roots.AppendCertsFromPEM(cp.caCert)
+	clientCAs := x509.NewCertPool()
+	ok := clientCAs.AppendCertsFromPEM(cp.caCert)
 	if !ok {
-		return nil, fmt.Errorf("failed to parse root certificate")
+		return nil, fmt.Errorf("failed to parse client CA certificate")
 	}
 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-	tlsConfig.ClientCAs = roots
+	tlsConfig.ClientCAs = clientCAs
 	return tlsConfig, nil
 }

--- a/pkg/collector/udp.go
+++ b/pkg/collector/udp.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"net"
 
 	"github.com/pion/dtls/v2"
@@ -34,27 +35,10 @@ func (cp *CollectingProcess) startUDPServer() {
 		return
 	}
 	if cp.isEncrypted { // use DTLS
-		if cp.tlsMinVersion != 0 && cp.tlsMinVersion != tls.VersionTLS12 {
-			klog.Error("DTLS 1.2 is the only supported version")
-			return
-		}
-		cert, err := tls.X509KeyPair(cp.serverCert, cp.serverKey)
+		config, err := cp.createServerDTLSConfig()
 		if err != nil {
 			klog.Error(err)
 			return
-		}
-		certPool := x509.NewCertPool()
-		certPool.AppendCertsFromPEM(cp.serverCert)
-		// If tlsConfig.CipherSuites is nil, cipherSuites should also be nil!
-		var cipherSuites []dtls.CipherSuiteID
-		for _, cipherSuite := range cp.tlsCipherSuites {
-			cipherSuites = append(cipherSuites, dtls.CipherSuiteID(cipherSuite))
-		}
-		config := &dtls.Config{
-			Certificates:         []tls.Certificate{cert},
-			ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-			ClientCAs:            certPool,
-			CipherSuites:         cipherSuites,
 		}
 		listener, err = dtls.Listen("udp", address, config)
 		if err != nil {
@@ -187,4 +171,35 @@ func (cp *CollectingProcess) createUDPClient(addr string) *transportSession {
 		}
 	}()
 	return session
+}
+
+func (cp *CollectingProcess) createServerDTLSConfig() (*dtls.Config, error) {
+	if cp.tlsMinVersion != 0 && cp.tlsMinVersion != tls.VersionTLS12 {
+		return nil, fmt.Errorf("DTLS 1.2 is the only supported version")
+	}
+	cert, err := tls.X509KeyPair(cp.serverCert, cp.serverKey)
+	if err != nil {
+		return nil, err
+	}
+	// If tlsConfig.CipherSuites is nil, cipherSuites should also be nil!
+	var cipherSuites []dtls.CipherSuiteID
+	for _, cipherSuite := range cp.tlsCipherSuites {
+		cipherSuites = append(cipherSuites, dtls.CipherSuiteID(cipherSuite))
+	}
+	config := &dtls.Config{
+		Certificates:         []tls.Certificate{cert},
+		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
+		CipherSuites:         cipherSuites,
+	}
+	if cp.caCert == nil {
+		return config, nil
+	}
+	clientCAs := x509.NewCertPool()
+	ok := clientCAs.AppendCertsFromPEM(cp.caCert)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse client CA certificate")
+	}
+	config.ClientAuth = dtls.RequireAndVerifyClientCert
+	config.ClientCAs = clientCAs
+	return config, nil
 }

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -76,6 +76,15 @@ type ExporterTLSClientConfig struct {
 	CertData []byte
 	// KeyData holds PEM-encoded bytes.
 	KeyData []byte
+	// List of supported cipher suites.
+	// From https://pkg.go.dev/crypto/tls#pkg-constants
+	// The order of the list is ignored.Note that TLS 1.3 ciphersuites are not configurable.
+	// For DTLS, cipher suites are from https://pkg.go.dev/github.com/pion/dtls/v2@v2.2.12/internal/ciphersuite#ID.
+	CipherSuites []uint16
+	// Min TLS version.
+	// From https://pkg.go.dev/crypto/tls#pkg-constants
+	// Not configurable for DTLS, as only DTLS 1.2 is supported.
+	MinVersion uint16
 }
 
 type ExporterInput struct {
@@ -173,17 +182,26 @@ func InitExportingProcess(input ExporterInput) (*ExportingProcess, error) {
 		case "udp": // use DTLS
 			// TODO: support client authentication
 			if len(tlsConfig.CertData) > 0 || len(tlsConfig.KeyData) > 0 {
-				klog.Error("Client-authentication is not supported yet for DTLS, cert and key data will be ignored")
+				return nil, fmt.Errorf("client-authentication is not supported yet for DTLS")
+			}
+			if tlsConfig.MinVersion != 0 && tlsConfig.MinVersion != tls.VersionTLS12 {
+				return nil, fmt.Errorf("DTLS 1.2 is the only supported version")
 			}
 			roots := x509.NewCertPool()
 			ok := roots.AppendCertsFromPEM(tlsConfig.CAData)
 			if !ok {
 				return nil, fmt.Errorf("failed to parse root certificate")
 			}
+			// If tlsConfig.CipherSuites is nil, cipherSuites should also be nil!
+			var cipherSuites []dtls.CipherSuiteID
+			for _, cipherSuite := range tlsConfig.CipherSuites {
+				cipherSuites = append(cipherSuites, dtls.CipherSuiteID(cipherSuite))
+			}
 			config := &dtls.Config{
 				RootCAs:              roots,
 				ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 				ServerName:           tlsConfig.ServerName,
+				CipherSuites:         cipherSuites,
 			}
 			udpAddr, err := net.ResolveUDPAddr(input.CollectorProtocol, input.CollectorAddress)
 			if err != nil {
@@ -621,21 +639,27 @@ func createClientConfig(config *ExporterTLSClientConfig) (*tls.Config, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to parse root certificate")
 	}
+	tlsMinVersion := config.MinVersion
+	// This should already be the default value for tls.Config, but we duplicate the earlier
+	// implementation, which was explicitly setting it to 1.2.
+	if tlsMinVersion == 0 {
+		tlsMinVersion = tls.VersionTLS12
+	}
+	// #nosec G402: client is in charge of setting the min TLS version. We use 1.2 as the
+	// default, which is secure.
+	tlsConfig := &tls.Config{
+		RootCAs:      roots,
+		ServerName:   config.ServerName,
+		CipherSuites: config.CipherSuites,
+		MinVersion:   tlsMinVersion,
+	}
 	if config.CertData == nil {
-		return &tls.Config{
-			RootCAs:    roots,
-			MinVersion: tls.VersionTLS12,
-			ServerName: config.ServerName,
-		}, nil
+		return tlsConfig, nil
 	}
 	cert, err := tls.X509KeyPair(config.CertData, config.KeyData)
 	if err != nil {
 		return nil, err
 	}
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      roots,
-		MinVersion:   tls.VersionTLS12,
-		ServerName:   config.ServerName,
-	}, nil
+	tlsConfig.Certificates = []tls.Certificate{cert}
+	return tlsConfig, nil
 }


### PR DESCRIPTION
We support providing a list of cipher suites, as well as a min TLS protocol version.
For DTLS, the version cannot be configured (only 1.2 is supported).