### PR TITLE
Do not close the udp connection to the collector if there are errors while sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.  The format
 Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Do not close the UDP connection to the collector if there are errors while sending (@vlet)
 ## 0.14.0 03-24-2025
 ### Fixed
 - Fix Record length computation so that IPFIX UDP messages can be sized

--- a/pkg/exporter/process.go
+++ b/pkg/exporter/process.go
@@ -284,11 +284,10 @@ func InitExportingProcess(input ExporterInput) (*ExportingProcess, error) {
 					klog.V(2).Info("Sending refreshed templates to the collector")
 					err := expProc.sendRefreshedTemplates()
 					if err != nil {
-						klog.Errorf("Error when sending refreshed templates, closing the connection to the collector: %v", err)
-						expProc.closeConnToCollector()
-						return
+						klog.Errorf("Error when sending refreshed templates: %v", err)
+					} else {
+						klog.V(2).Info("Sent refreshed templates to the collector")
 					}
-					klog.V(2).Info("Sent refreshed templates to the collector")
 				}
 			}
 		}()


### PR DESCRIPTION
Fixed the problem with permanently closing the connection to the collector (ipfix/udp mode), if the collector was unavailable for some time. Since the mechanism for repeated reconnection is not implemented, the exporter no longer closes the connection to the collector, but only reports the problem in the log.