### PR TITLE
feat: Add Antrea-specific IEs for external-to-pod

### DIFF
--- a/pkg/registry/registry_antrea.csv
+++ b/pkg/registry/registry_antrea.csv
@@ -67,3 +67,8 @@ ElementID,Name,Abstract Data Type,Data Type Semantics,Status,Description,Units,R
 165,egressNetworkPolicyUUID,octetArray,,current,,,,,,,,56506,16,
 166,egressUUID,octetArray,,current,,,,,,,,56506,16,
 167,egressNodeUUID,octetArray,,current,,,,,,,,56506,16,
+168,destinationServiceIPv4,ipv4Address,,current,,,,,,,,56506,,
+169,destinationServiceIPv6,ipv6Address,,current,,,,,,,,56506,,
+170,proxySnatIPv4,ipv4Address,,current,,,,,,,,56506,,
+171,proxySnatIPv6,ipv6Address,,current,,,,,,,,56506,,
+172,proxySnatPort,unsigned16,,current,,,,,,,,56506,,

--- a/pkg/registry/registry_antrea.go
+++ b/pkg/registry/registry_antrea.go
@@ -89,4 +89,9 @@ func loadAntreaRegistry() {
 	registerInfoElement(*entities.NewInfoElement("egressNetworkPolicyUUID", 165, 0, 56506, 16), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressUUID", 166, 0, 56506, 16), 56506)
 	registerInfoElement(*entities.NewInfoElement("egressNodeUUID", 167, 0, 56506, 16), 56506)
+	registerInfoElement(*entities.NewInfoElement("destinationServiceIPv4", 168, 18, 56506, 4), 56506)
+	registerInfoElement(*entities.NewInfoElement("destinationServiceIPv6", 169, 19, 56506, 16), 56506)
+	registerInfoElement(*entities.NewInfoElement("proxySnatIPv4", 170, 18, 56506, 4), 56506)
+	registerInfoElement(*entities.NewInfoElement("proxySnatIPv6", 171, 19, 56506, 16), 56506)
+	registerInfoElement(*entities.NewInfoElement("proxySnatPort", 172, 2, 56506, 2), 56506)
 }


### PR DESCRIPTION
These IEs can be used for correlating external-to-pod flows as is the case for Antrea's FlowAggregator. destinationServiceIP is added to eventually deprecate and replace destinationClusterIP

1. destinationServiceIPv4, destinationServiceIPv6: Records the Node's IP that traffic was originally routed to.
2. proxySnatIPv4, proxySnatIPv6: Records the SNAT IP used by Antrea.
3. proxySnatPort: Records the corresponding ephemeral SNAT port.