### PR TITLE
Fix flaky TestTCPCollectingProcess_ConcurrentClient

### DIFF
--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -355,8 +355,11 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 		if err != nil {
 			t.Errorf("Cannot establish connection to %s", collectorAddr.String())
 		}
-		time.Sleep(time.Millisecond)
-		assert.GreaterOrEqual(t, cp.GetNumConnToCollector(), int64(2), "There should be at least two tcp clients.")
+		// Poll until both connections are registered by the collector's accept loop,
+		// rather than relying on a fixed sleep that can be too short on slow CI runners.
+		assert.Eventually(t, func() bool {
+			return cp.GetNumConnToCollector() >= 2
+		}, 500*time.Millisecond, 10*time.Millisecond, "There should be at least two tcp clients.")
 		cp.Stop()
 	}()
 	cp.Start()


### PR DESCRIPTION
The test used a fixed 1ms sleep to wait for both TCP connections to be registered by the collector's accept loop before asserting the count. On loaded CI runners the scheduler often doesn't give the first goroutine enough time in that window, causing intermittent failures with "1 is not >= 2".

Replace the sleep with assert.Eventually, polling every 10ms for up to 500ms — the same retry-based pattern already used by waitForCollectorReady.