### PR TITLE
Fix goroutine leak in TestTCPCollectingProcess_ConcurrentClient

### DIFF
--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -338,7 +339,10 @@ func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 	input := getCollectorInput(tcpTransport, false, false)
 	cp, _ := InitCollectingProcess(input)
+	var wg sync.WaitGroup
+	wg.Add(2)
 	go func() {
+		defer wg.Done()
 		// wait until collector is ready
 		waitForCollectorReady(t, cp)
 		collectorAddr := cp.GetAddress()
@@ -348,6 +352,7 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 		}
 	}()
 	go func() {
+		defer wg.Done()
 		// wait until collector is ready
 		waitForCollectorReady(t, cp)
 		collectorAddr := cp.GetAddress()
@@ -359,10 +364,14 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 		// rather than relying on a fixed sleep that can be too short on slow CI runners.
 		assert.Eventually(t, func() bool {
 			return cp.GetNumConnToCollector() >= 2
-		}, 500*time.Millisecond, 10*time.Millisecond, "There should be at least two tcp clients.")
+		}, 5*time.Second, 10*time.Millisecond, "There should be at least two tcp clients.")
 		cp.Stop()
 	}()
 	cp.Start()
+	// Ensure both goroutines (and their calls into t) have finished before the
+	// test returns, otherwise a slow goroutine can call t.Errorf after the
+	// test has already completed, causing a panic.
+	wg.Wait()
 }
 
 func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {


### PR DESCRIPTION
One of the two client goroutines had no synchronization with test completion: cp.Start() only unblocks when the second goroutine calls cp.Stop(), so the first goroutine could still be dialing when the test function returned. If its net.Dial then failed against the now-closed listener, t.Errorf ran after the test was already marked done, causing "panic: Fail in goroutine after ... has completed".

Add a sync.WaitGroup so the test waits for both goroutines to finish before returning. Also bump the assert.Eventually timeout from 500ms to 5s, since the tighter window was itself intermittently too short under -race on loaded CI runners.