### PR TITLE
Fix flaky TestTCPCollectingProcess_ConcurrentClient

### DIFF
--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -354,6 +354,7 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 	// are connected to the collector simultaneously. They also need to be referenced
 	// until then, as the garbage collector closes unreachable connections.
 	conns := make([]net.Conn, numClients)
+	sessionIDs := make([]string, numClients)
 	var wg sync.WaitGroup
 	for i := range numClients {
 		wg.Add(1)
@@ -366,10 +367,9 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 				return
 			}
 			conns[i] = conn
+			sessionIDs[i] = localConnSessionID(conn)
 		}()
 	}
-	// All the clients connect concurrently, but we wait for all of them to be connected
-	// before asserting anything about the collector's sessions.
 	wg.Wait()
 	for _, conn := range conns {
 		if conn != nil {
@@ -377,10 +377,22 @@ func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 		}
 	}
 
-	// Sessions are registered asynchronously by the accept loop, hence Eventually.
+	// Check for these specific sessions, and not just the session count, so that the
+	// assertion cannot be satisfied by an unrelated session. Sessions are registered
+	// asynchronously by the accept loop, hence Eventually.
 	assert.Eventually(t, func() bool {
-		return cp.GetNumConnToCollector() >= numClients
-	}, 5*time.Second, 10*time.Millisecond, "There should be at least two tcp clients.")
+		cp.mutex.RLock()
+		defer cp.mutex.RUnlock()
+		if len(cp.sessions) != numClients {
+			return false
+		}
+		for _, id := range sessionIDs {
+			if _, ok := cp.sessions[id]; !ok {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 10*time.Millisecond, "The collector should have a session for each tcp client.")
 }
 
 func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {
@@ -1032,18 +1044,22 @@ func getCollectorInput(network string, isEncrypted bool, isIPv6 bool) CollectorI
 	}
 }
 
+// waitForCollectorReady waits until the collector's socket is bound and its listening
+// address is available. Both the TCP and the UDP code paths bind the socket before
+// calling updateAddress, so a non-nil address means that the kernel is already queuing
+// incoming connections / datagrams for the collector, even if its accept or read loop
+// has not been scheduled yet.
+//
+// It deliberately does not dial the collector to probe for readiness: such a connection
+// is registered as a session by the TCP accept loop, and is only unregistered
+// asynchronously after it is closed, which contaminates session assertions in tests.
 func waitForCollectorReady(t *testing.T, cp *CollectingProcess) {
-	checkConn := func(ctx context.Context) (bool, error) {
-		if conn, err := net.Dial(cp.GetAddress().Network(), cp.GetAddress().String()); err != nil {
-			return false, err
-		} else {
-			defer conn.Close()
-			return true, nil
-		}
+	t.Helper()
+	checkAddr := func(ctx context.Context) (bool, error) {
+		return cp.GetAddress() != nil, nil
 	}
-	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 500*time.Millisecond, false, checkConn); err != nil {
-		t.Errorf("Cannot establish connection to %s", cp.GetAddress().String())
-	}
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 5*time.Second, true, checkAddr)
+	require.NoError(t, err, "Collecting process is not ready")
 }
 
 func disableLogToStderr() {

--- a/pkg/collector/process_test.go
+++ b/pkg/collector/process_test.go
@@ -340,39 +340,47 @@ func TestUDPCollectingProcess_ReceiveDataRecord(t *testing.T) {
 func TestTCPCollectingProcess_ConcurrentClient(t *testing.T) {
 	input := getCollectorInput(tcpTransport, false, false)
 	cp, _ := InitCollectingProcess(input)
+	go cp.Start()
+	// Stop the collector when the test returns, and never before: stopping it from one
+	// of the client goroutines below used to race with the other clients, which could
+	// then fail to connect.
+	defer cp.Stop()
+	// wait until collector is ready
+	waitForCollectorReady(t, cp)
+	collectorAddr := cp.GetAddress()
+
+	const numClients = 2
+	// The connections are kept open until the end of the test, so that all the clients
+	// are connected to the collector simultaneously. They also need to be referenced
+	// until then, as the garbage collector closes unreachable connections.
+	conns := make([]net.Conn, numClients)
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		// wait until collector is ready
-		waitForCollectorReady(t, cp)
-		collectorAddr := cp.GetAddress()
-		_, err := net.Dial(collectorAddr.Network(), collectorAddr.String())
-		if err != nil {
-			t.Errorf("Cannot establish connection to %s", collectorAddr.String())
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		// wait until collector is ready
-		waitForCollectorReady(t, cp)
-		collectorAddr := cp.GetAddress()
-		_, err := net.Dial(collectorAddr.Network(), collectorAddr.String())
-		if err != nil {
-			t.Errorf("Cannot establish connection to %s", collectorAddr.String())
-		}
-		// Poll until both connections are registered by the collector's accept loop,
-		// rather than relying on a fixed sleep that can be too short on slow CI runners.
-		assert.Eventually(t, func() bool {
-			return cp.GetNumConnToCollector() >= 2
-		}, 5*time.Second, 10*time.Millisecond, "There should be at least two tcp clients.")
-		cp.Stop()
-	}()
-	cp.Start()
-	// Ensure both goroutines (and their calls into t) have finished before the
-	// test returns, otherwise a slow goroutine can call t.Errorf after the
-	// test has already completed, causing a panic.
+	for i := range numClients {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := net.Dial(collectorAddr.Network(), collectorAddr.String())
+			// Use assert and not require, which must not be called from a goroutine
+			// other than the one running the test.
+			if !assert.NoErrorf(t, err, "Cannot establish connection to %s", collectorAddr.String()) {
+				return
+			}
+			conns[i] = conn
+		}()
+	}
+	// All the clients connect concurrently, but we wait for all of them to be connected
+	// before asserting anything about the collector's sessions.
 	wg.Wait()
+	for _, conn := range conns {
+		if conn != nil {
+			defer conn.Close()
+		}
+	}
+
+	// Sessions are registered asynchronously by the accept loop, hence Eventually.
+	assert.Eventually(t, func() bool {
+		return cp.GetNumConnToCollector() >= numClients
+	}, 5*time.Second, 10*time.Millisecond, "There should be at least two tcp clients.")
 }
 
 func TestUDPCollectingProcess_ConcurrentClient(t *testing.T) {


### PR DESCRIPTION
`TestTCPCollectingProcess_ConcurrentClient` fails intermittently in CI on main, e.g.:

```
--- FAIL: TestTCPCollectingProcess_ConcurrentClient (0.10s)
    process_test.go:352: Cannot establish connection to 127.0.0.1:36861
```

### Cause

The test stopped the collector from inside one of the client goroutines, as soon as that goroutine observed at least 2 sessions. Nothing guaranteed that the other client had connected by then, so the listener could be closed before the other client dialed.

The session count is not a reliable signal for this: `waitForCollectorReady` dials the collector to probe for readiness, and for TCP that probe connection is itself registered as a session by the accept loop, and is only unregistered asynchronously after it is closed. Both goroutines run a probe, so the `>= 2` condition could be satisfied by the two probe connections alone, before either client had connected.

### Changes

Split into two commits:

1. **Fix the flake.** Stop the collector when the test returns, once all clients are known to be connected, rather than from a client goroutine. The clients still connect concurrently, which is the point of the test. The connections are also kept open and referenced until the end of the test — they used to be discarded immediately, allowing the garbage collector to close them at any point.

2. **Stop dialing the collector in `waitForCollectorReady`.** Both the TCP and UDP code paths bind the socket before publishing the collector's address, so waiting for that address is sufficient and has no side effect on the collector. For UDP the old probe never proved anything anyway, since dialing a UDP socket is a purely local operation. With the interference gone, the test now asserts that the collector has a session for each client and no other session, instead of asserting on the count only.

### Testing

- Reproduced the original failure with the exact CI message by stressing the pre-fix test under scheduling pressure (`-race -cpu=1`, parallel runs).
- The fixed test passes 900 runs under the same conditions; the whole package passes 120 runs.
- Verified the new assertion is falsifiable: with a deliberately introduced regression that registers sessions under the wrong key, the new assertion fails while the previous count-based one passes.
- `go test -race ./...` and `go vet -tags integration ./...` are clean.

As a side effect, the tests get faster, since `waitForCollectorReady` no longer imposes a 100ms minimum delay at each of its 17 call sites. Locally, over 5 runs of `go test -race ./pkg/collector/`, the reported test time goes from 3.78-4.27s on main to 2.16-2.27s. The full unit suite (`go test -race ./...`) goes from 6.08-6.28s to 5.77-5.88s wall time over 3 runs.

Note: `pkg/test/collector_intermediate_test.go` has its own copy of `waitForCollectorReady` with the same probe-dial pattern. It is left untouched here, as no test in that package asserts on the collector's sessions.
